### PR TITLE
Ensure board member settings saves and refine team board UI

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1,0 +1,31 @@
+# Admin API Setup
+
+Die Admin-Ansicht verwendet serverseitige API-Routen, um Benutzer- und Abteilungsdaten mit erhöhten Rechten zu ändern. Wenn verfügbar, nutzen die Routen automatisch den Supabase Service-Role-Key. Fehlt der Key, fällt das System auf den authentifizierten Benutzerkontext zurück und übernimmt dessen Session-Cookies, sodass zumindest Änderungen am eigenen Profil (z. B. sich selbst zum Admin befördern) möglich bleiben, während privilegierte Aktionen mit einem Hinweis abbrechen.
+
+## Benötigte Umgebungsvariablen
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=deine-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=dein-anon-key
+SUPABASE_SERVICE_ROLE_KEY=dein-service-role-key
+```
+
+> **Wichtig:** Der Service-Role-Key darf niemals im Browser landen. Hinterlege ihn nur in serverseitigen Umgebungen (.env.local, Vercel Project Settings etc.). Ohne den Key bleiben sensitive Operationen gesperrt und die API meldet dies mit einem eindeutigen Fehler. Die beiden `NEXT_PUBLIC_*`-Variablen werden bereits für das restliche Frontend benötigt – die Admin-API greift bei fehlendem Service-Role-Key ebenfalls darauf zurück.
+
+## Benötigte Tabellen & Policies
+
+* `profiles` – enthält die Felder `full_name`, `role`, `company`, `is_active` usw.
+* `departments` – referenziert die verfügbaren Abteilungen.
+
+Die API-Routen erwarten, dass dein Supabase-Schema INSERT/UPDATE/DELETE über den Service-Role-Key erlaubt. Zusätzliche RLS-Policies sind nicht erforderlich, solange der Service-Role-Key verwendet wird.
+
+## Verfügbare Endpunkte
+
+| Methode & Pfad | Beschreibung |
+| --- | --- |
+| `PATCH /api/admin/users/:id` | Aktualisiert Name, Rolle, Abteilung oder Aktiv-Status eines Profils. Ohne Service-Role-Key sind nur Änderungen am eigenen Profil möglich. |
+| `DELETE /api/admin/users/:id` | Entfernt Benutzer (inklusive Supabase Auth-Account) dauerhaft. Erfordert zwingend den Service-Role-Key. |
+| `POST /api/admin/departments` | Legt eine neue Abteilung an. Erfordert den Service-Role-Key oder angepasste Supabase-Policies. |
+| `DELETE /api/admin/departments/:id` | Löscht eine vorhandene Abteilung. Erfordert den Service-Role-Key oder angepasste Supabase-Policies. |
+
+Die Admin-Oberfläche ruft diese Endpunkte direkt auf. Stelle sicher, dass deine Umgebung korrekt konfiguriert ist, bevor du Benutzeränderungen durchführst.

--- a/docs/attendance-toggle.sql
+++ b/docs/attendance-toggle.sql
@@ -1,0 +1,89 @@
+-- Normalise historische Anwesenheitswerte auf das neue present/absent-Modell
+update public.board_attendance
+set status = case
+  when status in ('absent', 'sick', 'vacation', 'remote') then 'absent'
+  else 'present'
+end;
+
+-- Standardwert und Check-Constraint setzen
+alter table public.board_attendance
+  alter column status set default 'present';
+
+do $$
+begin
+  if exists (
+    select 1
+    from information_schema.constraint_column_usage
+    where table_schema = 'public'
+      and table_name = 'board_attendance'
+      and constraint_name = 'board_attendance_status_check'
+  ) then
+    alter table public.board_attendance drop constraint board_attendance_status_check;
+  end if;
+end;
+$$;
+
+alter table public.board_attendance
+  add constraint board_attendance_status_check
+  check (status in ('present', 'absent'));
+
+-- Index zur schnelleren Abfrage nach Board und Kalenderwoche
+create index if not exists board_attendance_board_week_idx
+  on public.board_attendance (board_id, week_start desc);
+
+-- Optionale Sicht, die jede gespeicherte KW nur einmal zurückliefert
+create or replace view public.board_attendance_weeks as
+select
+  board_id,
+  week_start,
+  min(created_at) as first_recorded_at
+from public.board_attendance
+group by board_id, week_start
+order by board_id, week_start desc;
+
+grant select on public.board_attendance_weeks to authenticated;
+
+-- Matrix-View für die neue Anwesenheitstabelle im Management-Panel
+create or replace view public.board_attendance_matrix as
+select
+  ba.board_id,
+  ba.week_start,
+  jsonb_object_agg(ba.profile_id::text, jsonb_build_object('status', ba.status)) as statuses
+from public.board_attendance ba
+group by ba.board_id, ba.week_start
+order by ba.board_id, ba.week_start desc;
+
+grant select on public.board_attendance_matrix to authenticated;
+
+-- Lückenlose Wochenliste je Board inkl. aktueller Kalenderwoche
+create or replace view public.board_attendance_week_series as
+with bounds as (
+  select
+    board_id,
+    min(week_start) as first_week,
+    greatest(max(week_start), date_trunc('week', current_date)::date) as last_week
+  from public.board_attendance
+  group by board_id
+),
+series as (
+  select
+    b.board_id,
+    generate_series(b.first_week, b.last_week, interval '7 days')::date as week_start
+  from bounds b
+  union
+  select
+    kb.id as board_id,
+    date_trunc('week', current_date)::date as week_start
+  from public.kanban_boards kb
+)
+select
+  s.board_id,
+  s.week_start,
+  coalesce(m.statuses, '{}'::jsonb) as statuses
+from series s
+left join public.board_attendance_matrix m
+  on m.board_id = s.board_id
+ and m.week_start = s.week_start
+order by s.board_id, s.week_start desc;
+
+grant select on public.board_attendance_week_series to authenticated;

--- a/docs/board-escalation-history.sql
+++ b/docs/board-escalation-history.sql
@@ -1,0 +1,36 @@
+-- Ensure the escalation history table exists so the management UI can
+-- record who changed an escalation and when.
+
+begin;
+
+set search_path = public;
+
+create table if not exists public.board_escalation_history (
+  id             uuid primary key default gen_random_uuid(),
+  board_id       uuid not null references public.kanban_boards(id) on delete cascade,
+  card_id        text not null,
+  escalation_id  uuid references public.board_escalations(id) on delete cascade,
+  changed_by     uuid references public.profiles(id) on delete set null,
+  changes        jsonb not null default '{}'::jsonb,
+  changed_at     timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists board_escalation_history_board_card_idx
+  on public.board_escalation_history (board_id, card_id, changed_at desc);
+
+create index if not exists board_escalation_history_escalation_idx
+  on public.board_escalation_history (escalation_id, changed_at desc);
+
+alter table public.board_escalation_history enable row level security;
+
+create policy if not exists "Authenticated users can read escalation history"
+  on public.board_escalation_history
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy if not exists "Authenticated users can write escalation history"
+  on public.board_escalation_history
+  for insert
+  with check (auth.role() = 'authenticated');
+
+commit;

--- a/docs/board-members-card-policy.sql
+++ b/docs/board-members-card-policy.sql
@@ -1,0 +1,28 @@
+-- Adds an RLS policy so board members (and the superuser) may edit Kanban cards.
+begin;
+
+drop policy if exists "Board members manage board cards" on public.kanban_cards;
+
+create policy "Board members manage board cards"
+  on public.kanban_cards
+  for all
+  using (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  );
+
+commit;

--- a/docs/board-settings-member-policy.sql
+++ b/docs/board-settings-member-policy.sql
@@ -1,0 +1,28 @@
+-- Allows board members (and the superuser) to manage board settings alongside the owner.
+begin;
+
+drop policy if exists "Board members manage board settings" on public.kanban_board_settings;
+
+create policy "Board members manage board settings"
+  on public.kanban_board_settings
+  for all
+  using (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  );
+
+commit;

--- a/docs/board-teamboards.sql
+++ b/docs/board-teamboards.sql
@@ -1,0 +1,15 @@
+-- Ensure every board stores its type ("standard" vs "team") in the settings JSON.
+-- Run this once after deploying the team board feature.
+
+alter table public.kanban_boards
+  alter column settings set default '{"boardType":"standard"}'::jsonb;
+
+update public.kanban_boards
+set settings = jsonb_set(coalesce(settings, '{}'::jsonb), '{boardType}', '"standard"', true)
+where coalesce(settings->>'boardType', '') = '';
+
+-- To convert an existing board into a team board replace the placeholder UUID
+-- with the actual board id and execute the statement below.
+-- update public.kanban_boards
+-- set settings = jsonb_set(coalesce(settings, '{}'::jsonb), '{boardType}', '"team"', true)
+-- where id = '00000000-0000-0000-0000-000000000000';

--- a/docs/mariadb-migration.md
+++ b/docs/mariadb-migration.md
@@ -1,0 +1,30 @@
+# Evaluating a Migration from Supabase to MariaDB
+
+This project relies heavily on Supabase for both data persistence and authentication. Supabase provides:
+
+- Managed Postgres database with row-level security and RPC support.
+- Built-in authentication (sign-in, password reset, admin APIs).
+- Client SDK used directly in the React application (`@supabase/supabase-js`).
+
+## Current Supabase Touchpoints
+
+Key areas that instantiate Supabase clients or call Supabase-specific features:
+
+- `src/contexts/AuthContext.tsx` – handles login, logout, session refresh, and admin-only user listing via `supabase.auth.admin`.
+- `src/app/page.tsx` – loads Kanban boards using direct table queries and the `list_all_boards` RPC.
+- `src/components/kanban/OriginalKanbanBoard.tsx` and related helpers – query boards, columns, cards, and updates live via Supabase channels.
+- `src/components/admin/UserManagement.tsx` – performs profile CRUD, department assignment, and account provisioning with admin APIs.
+
+## Implications of Switching to MariaDB
+
+Moving to MariaDB would require rebuilding both the authentication flow and data access layer:
+
+1. **Authentication Replacement** – Supabase Auth is Postgres-backed; MariaDB would need an alternative (e.g., NextAuth with credential/OIDC providers) plus new tables for users, sessions, password hashes, and audit trails.
+2. **API Layer Introduction** – The frontend currently communicates directly with Supabase. A MariaDB setup would necessitate REST or GraphQL endpoints (Next.js API routes, NestJS, Express) or an ORM like Prisma/TypeORM to bridge the database.
+3. **Rewriting RPCs and Triggers** – Functions such as `list_all_boards` and row-level security policies need MariaDB equivalents (stored procedures, views, or service logic).
+4. **Model Migration** – Existing tables (`kanban_boards`, `board_columns`, `cards`, `profiles`, `departments`, etc.) depend on Postgres data types (UUID, JSON). These must be adapted to MariaDB-compatible types and constraints.
+5. **Frontend Refactor** – Every Supabase call (`createClient`, `.from()`, `.rpc()`) must be redirected to the new API. This affects authentication context, board fetching, admin dashboards, and real-time updates.
+
+## Recommendation
+
+Supabase remains the more practical choice for this codebase because it bundles the necessary auth, database, and real-time capabilities already integrated throughout the app. A MariaDB migration would amount to a comprehensive re-architecture touching most files and introducing significant new backend infrastructure.

--- a/docs/patch-board-escalations-card-id.sql
+++ b/docs/patch-board-escalations-card-id.sql
@@ -1,0 +1,23 @@
+--
+-- Stellt sicher, dass die Tabelle "board_escalations" die erwartete Spalte
+-- "card_id" enthält und dass pro Board immer nur eine Eskalation je Karte
+-- existiert. Das Skript ist idempotent und kann gefahrlos erneut ausgeführt
+-- werden.
+--
+begin;
+
+alter table public.board_escalations
+  add column if not exists card_id text;
+
+update public.board_escalations
+set card_id = coalesce(card_id, project_code, id::text)
+where card_id is null;
+
+alter table public.board_escalations
+  alter column card_id set not null;
+
+drop index if exists board_escalations_board_card_id_idx;
+create unique index board_escalations_board_card_id_idx
+  on public.board_escalations (board_id, card_id);
+
+commit;

--- a/docs/supabase-reset.sql
+++ b/docs/supabase-reset.sql
@@ -1,0 +1,553 @@
+-- Reset and rebuild the Projektboard schema.
+-- ⚠️ This script DROPS existing tables and functions before recreating them.
+--    Run it only if you are comfortable losing the current board/profile data.
+--
+-- Recommended execution order:
+--   1. Open Supabase SQL editor.
+--   2. Paste this script.
+--   3. Execute in a single transaction.
+--
+-- The script assumes the `pgcrypto` extension is available (default on Supabase)
+-- so that `gen_random_uuid()` works.
+
+begin;
+
+set search_path = public;
+
+-- ---------------------------------------------------------------------------
+-- Drop legacy objects so we can recreate a clean schema
+-- ---------------------------------------------------------------------------
+
+-- helper triggers/functions
+drop trigger if exists set_departments_updated_at on public.departments;
+drop trigger if exists set_profiles_updated_at on public.profiles;
+drop trigger if exists set_kanban_boards_updated_at on public.kanban_boards;
+drop trigger if exists set_board_settings_updated_at on public.kanban_board_settings;
+drop trigger if exists set_cards_updated_at on public.kanban_cards;
+drop trigger if exists sync_profile_from_auth on auth.users;
+
+drop function if exists public.handle_profiles_updated_at();
+drop function if exists public.handle_kanban_boards_updated_at();
+drop function if exists public.handle_board_settings_updated_at();
+drop function if exists public.handle_kanban_cards_updated_at();
+drop function if exists public.set_updated_at();
+drop function if exists public.list_all_boards();
+drop function if exists public.handle_new_auth_user();
+
+-- legacy/unused tables from the earlier implementation
+drop table if exists public.team_members cascade;
+drop table if exists public.teams cascade;
+
+-- main domain tables
+drop table if exists public.board_escalation_history cascade;
+drop table if exists public.board_escalations cascade;
+drop table if exists public.board_top_topics cascade;
+drop table if exists public.board_attendance cascade;
+drop table if exists public.board_members cascade;
+drop table if exists public.kanban_cards cascade;
+drop table if exists public.kanban_board_settings cascade;
+drop table if exists public.kanban_boards cascade;
+drop table if exists public.departments cascade;
+drop table if exists public.profiles cascade;
+
+-- ---------------------------------------------------------------------------
+-- Helper function for automatic updated_at handling
+-- ---------------------------------------------------------------------------
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := timezone('utc', now());
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Core data tables
+-- ---------------------------------------------------------------------------
+
+create table public.departments (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null unique,
+  created_at  timestamptz not null default timezone('utc', now()),
+  updated_at  timestamptz not null default timezone('utc', now())
+);
+
+create trigger set_departments_updated_at
+  before update on public.departments
+  for each row
+  execute function public.set_updated_at();
+
+create table public.profiles (
+  id          uuid primary key references auth.users(id) on delete cascade,
+  email       text not null unique,
+  full_name   text,
+  avatar_url  text,
+  bio         text,
+  company     text,
+  role        text not null default 'user',
+  is_active   boolean not null default true,
+  created_at  timestamptz not null default timezone('utc', now()),
+  updated_at  timestamptz not null default timezone('utc', now())
+);
+
+create trigger set_profiles_updated_at
+  before update on public.profiles
+  for each row
+  execute function public.set_updated_at();
+
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, email, full_name, role, company, is_active)
+  values (
+    new.id,
+    new.email,
+    coalesce(nullif(new.raw_user_meta_data->>'full_name', ''), new.email),
+    coalesce(nullif(new.raw_user_meta_data->>'role', ''), 'user'),
+    nullif(new.raw_user_meta_data->>'company', ''),
+    true
+  )
+  on conflict (id) do update
+    set email = excluded.email,
+        full_name = coalesce(nullif(excluded.full_name, ''), public.profiles.full_name),
+        role = coalesce(nullif(excluded.role, ''), public.profiles.role),
+        company = coalesce(excluded.company, public.profiles.company),
+        is_active = true;
+
+  return new;
+end;
+$$;
+
+create trigger sync_profile_from_auth
+  after insert or update on auth.users
+  for each row
+  execute function public.handle_new_auth_user();
+
+create table public.kanban_boards (
+  id           uuid primary key default gen_random_uuid(),
+  name         text not null,
+  description  text,
+  settings     jsonb not null default '{"boardType":"standard"}'::jsonb,
+  visibility   text not null default 'public' check (visibility in ('public', 'private')),
+  owner_id     uuid references auth.users(id) on delete set null,
+  user_id      uuid references auth.users(id) on delete set null,
+  created_at   timestamptz not null default timezone('utc', now()),
+  updated_at   timestamptz not null default timezone('utc', now())
+);
+
+create index kanban_boards_owner_idx on public.kanban_boards (owner_id);
+create index kanban_boards_visibility_idx on public.kanban_boards (visibility);
+
+create trigger set_kanban_boards_updated_at
+  before update on public.kanban_boards
+  for each row
+  execute function public.set_updated_at();
+
+create table public.kanban_board_settings (
+  board_id    uuid primary key references public.kanban_boards(id) on delete cascade,
+  user_id     uuid references auth.users(id) on delete set null,
+  settings    jsonb not null default '{}'::jsonb,
+  created_at  timestamptz not null default timezone('utc', now()),
+  updated_at  timestamptz not null default timezone('utc', now())
+);
+
+create trigger set_board_settings_updated_at
+  before update on public.kanban_board_settings
+  for each row
+  execute function public.set_updated_at();
+
+create table public.board_members (
+  id          uuid primary key default gen_random_uuid(),
+  board_id    uuid not null references public.kanban_boards(id) on delete cascade,
+  profile_id  uuid not null references public.profiles(id) on delete cascade,
+  created_at  timestamptz not null default timezone('utc', now())
+);
+
+create unique index board_members_unique on public.board_members (board_id, profile_id);
+
+create table public.board_attendance (
+  id           uuid primary key default gen_random_uuid(),
+  board_id     uuid not null references public.kanban_boards(id) on delete cascade,
+  profile_id   uuid not null references public.profiles(id) on delete cascade,
+  week_start   date not null,
+  status       text not null default 'present' check (status in ('present', 'absent')),
+  created_at   timestamptz not null default timezone('utc', now()),
+  updated_at   timestamptz not null default timezone('utc', now()),
+  constraint board_attendance_unique unique (board_id, profile_id, week_start)
+);
+
+create trigger set_board_attendance_updated_at
+  before update on public.board_attendance
+  for each row
+  execute function public.set_updated_at();
+
+create table public.board_top_topics (
+  id          uuid primary key default gen_random_uuid(),
+  board_id    uuid not null references public.kanban_boards(id) on delete cascade,
+  title       text not null default '',
+  position    integer not null default 0,
+  created_at  timestamptz not null default timezone('utc', now()),
+  updated_at  timestamptz not null default timezone('utc', now())
+);
+
+create index board_top_topics_board_position_idx on public.board_top_topics (board_id, position);
+
+create trigger set_board_top_topics_updated_at
+  before update on public.board_top_topics
+  for each row
+  execute function public.set_updated_at();
+
+create table public.board_escalations (
+  id                uuid primary key default gen_random_uuid(),
+  board_id          uuid not null references public.kanban_boards(id) on delete cascade,
+  card_id           text not null,
+  category          text not null check (category in ('LK', 'SK')),
+  project_code      text,
+  project_name      text,
+  reason            text,
+  measure           text,
+  department_id     uuid references public.departments(id) on delete set null,
+  responsible_id    uuid references public.profiles(id) on delete set null,
+  target_date       date,
+  completion_steps  integer not null default 0 check (completion_steps between 0 and 4),
+  created_at        timestamptz not null default timezone('utc', now()),
+  updated_at        timestamptz not null default timezone('utc', now())
+);
+
+create index board_escalations_board_category_idx on public.board_escalations (board_id, category);
+create unique index board_escalations_board_card_id_idx on public.board_escalations (board_id, card_id);
+
+create trigger set_board_escalations_updated_at
+  before update on public.board_escalations
+  for each row
+  execute function public.set_updated_at();
+
+create table public.board_escalation_history (
+  id             uuid primary key default gen_random_uuid(),
+  board_id       uuid not null references public.kanban_boards(id) on delete cascade,
+  card_id        text not null,
+  escalation_id  uuid references public.board_escalations(id) on delete cascade,
+  changed_by     uuid references public.profiles(id) on delete set null,
+  changes        jsonb not null default '{}'::jsonb,
+  changed_at     timestamptz not null default timezone('utc', now())
+);
+
+create index board_escalation_history_board_card_idx
+  on public.board_escalation_history (board_id, card_id, changed_at desc);
+create index board_escalation_history_escalation_idx
+  on public.board_escalation_history (escalation_id, changed_at desc);
+
+create table public.kanban_cards (
+  id             uuid primary key default gen_random_uuid(),
+  board_id       uuid not null references public.kanban_boards(id) on delete cascade,
+  card_id        text not null,
+  card_data      jsonb not null,
+  stage          text,
+  position       integer,
+  project_number text,
+  project_name   text,
+  created_at     timestamptz not null default timezone('utc', now()),
+  updated_at     timestamptz not null default timezone('utc', now())
+);
+
+create unique index kanban_cards_board_card_id_idx on public.kanban_cards (board_id, card_id);
+create index kanban_cards_stage_idx on public.kanban_cards (board_id, stage, position);
+
+create trigger set_cards_updated_at
+  before update on public.kanban_cards
+  for each row
+  execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security and policies
+-- ---------------------------------------------------------------------------
+
+alter table public.departments enable row level security;
+alter table public.profiles enable row level security;
+alter table public.kanban_boards enable row level security;
+alter table public.kanban_board_settings enable row level security;
+alter table public.kanban_cards enable row level security;
+alter table public.board_members enable row level security;
+alter table public.board_attendance enable row level security;
+alter table public.board_top_topics enable row level security;
+alter table public.board_escalations enable row level security;
+alter table public.board_escalation_history enable row level security;
+
+-- Departments: allow everyone signed-in to read; mutations handled via service role.
+create policy "Authenticated users can read departments"
+  on public.departments
+  for select
+  using (auth.role() = 'authenticated');
+
+-- Profiles: allow signed-in users to read everyone and edit themselves.
+create policy "Authenticated users can read profiles"
+  on public.profiles
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Users can update their own profile"
+  on public.profiles
+  for update
+  using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+-- Boards: public boards visible to all authenticated users.
+create policy "Authenticated users can read public boards"
+  on public.kanban_boards
+  for select
+  using (visibility = 'public');
+
+create policy "Board owners manage their boards"
+  on public.kanban_boards
+  for all
+  using (auth.uid() = owner_id)
+  with check (auth.uid() = owner_id);
+
+-- Board settings inherit board visibility for reads; only owners may mutate.
+create policy "Authenticated users can read board settings"
+  on public.kanban_board_settings
+  for select
+  using (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.visibility = 'public'
+    )
+  );
+
+create policy "Board owners manage board settings"
+  on public.kanban_board_settings
+  for all
+  using (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.owner_id = auth.uid()
+    )
+  );
+
+create policy "Board members manage board settings"
+  on public.kanban_board_settings
+  for all
+  using (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  );
+
+-- Cards: readable when the parent board is public; owners can mutate.
+create policy "Authenticated users can read board cards"
+  on public.kanban_cards
+  for select
+  using (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.visibility = 'public'
+    )
+  );
+
+create policy "Board owners manage board cards"
+  on public.kanban_cards
+  for all
+  using (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.owner_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from public.kanban_boards b
+      where b.id = board_id
+        and b.owner_id = auth.uid()
+    )
+  );
+
+create policy "Board members manage board cards"
+  on public.kanban_cards
+  for all
+  using (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  )
+  with check (
+    auth.email() = 'michael@mysight.net'
+    or exists (
+      select 1
+      from public.board_members bm
+      where bm.board_id = board_id
+        and bm.profile_id = auth.uid()
+    )
+  );
+
+-- Board management helpers
+create policy "Authenticated users can read board members"
+  on public.board_members
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users manage board members"
+  on public.board_members
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Authenticated users can read attendance"
+  on public.board_attendance
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users manage attendance"
+  on public.board_attendance
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Authenticated users can read top topics"
+  on public.board_top_topics
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users manage top topics"
+  on public.board_top_topics
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Authenticated users can read escalations"
+  on public.board_escalations
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users manage escalations"
+  on public.board_escalations
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Authenticated users can read escalation history"
+  on public.board_escalation_history
+  for select
+  using (auth.role() = 'authenticated');
+
+create policy "Authenticated users can write escalation history"
+  on public.board_escalation_history
+  for insert
+  with check (auth.role() = 'authenticated');
+
+-- Aggregierte Ansichten für die Anwesenheitsübersicht
+create or replace view public.board_attendance_weeks as
+select
+  board_id,
+  week_start,
+  min(created_at) as first_recorded_at
+from public.board_attendance
+group by board_id, week_start
+order by board_id, week_start desc;
+
+grant select on public.board_attendance_weeks to authenticated;
+
+create or replace view public.board_attendance_matrix as
+select
+  ba.board_id,
+  ba.week_start,
+  jsonb_object_agg(ba.profile_id::text, jsonb_build_object('status', ba.status)) as statuses
+from public.board_attendance ba
+group by ba.board_id, ba.week_start
+order by ba.board_id, ba.week_start desc;
+
+grant select on public.board_attendance_matrix to authenticated;
+
+create or replace view public.board_attendance_week_series as
+with bounds as (
+  select
+    board_id,
+    min(week_start) as first_week,
+    greatest(max(week_start), date_trunc('week', current_date)::date) as last_week
+  from public.board_attendance
+  group by board_id
+),
+series as (
+  select
+    b.board_id,
+    generate_series(b.first_week, b.last_week, interval '7 days')::date as week_start
+  from bounds b
+  union
+  select
+    kb.id as board_id,
+    date_trunc('week', current_date)::date as week_start
+  from public.kanban_boards kb
+)
+select
+  s.board_id,
+  s.week_start,
+  coalesce(m.statuses, '{}'::jsonb) as statuses
+from series s
+left join public.board_attendance_matrix m
+  on m.board_id = s.board_id
+ and m.week_start = s.week_start
+order by s.board_id, s.week_start desc;
+
+grant select on public.board_attendance_week_series to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Helper function used by the frontend to list every public board
+-- ---------------------------------------------------------------------------
+
+create or replace function public.list_all_boards()
+returns setof public.kanban_boards
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select *
+  from public.kanban_boards
+  where visibility = 'public'
+  order by coalesce(updated_at, created_at) desc;
+$$;
+
+revoke all on function public.list_all_boards() from public;
+grant execute on function public.list_all_boards() to authenticated;
+
+commit;

--- a/src/app/api/admin/departments/[id]/route.ts
+++ b/src/app/api/admin/departments/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveAdminSupabaseClient } from '@/lib/supabaseServer';
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  const { client: supabase, isService } = await resolveAdminSupabaseClient();
+
+  if (!isService) {
+    return NextResponse.json(
+      {
+        error:
+          'Zum Löschen von Abteilungen wird ein SUPABASE_SERVICE_ROLE_KEY oder passende Supabase-Policies benötigt.'
+      },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const { error } = await supabase.from('departments').delete().eq('id', params.id);
+
+    if (error) {
+      console.error('Delete department error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('DELETE /departments error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/departments/route.ts
+++ b/src/app/api/admin/departments/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveAdminSupabaseClient } from '@/lib/supabaseServer';
+
+export async function POST(request: NextRequest) {
+  const { client: supabase, isService } = await resolveAdminSupabaseClient();
+
+  try {
+    const { name } = await request.json();
+    const trimmedName = typeof name === 'string' ? name.trim() : '';
+
+    if (!trimmedName) {
+      return NextResponse.json({ error: 'Abteilungsname ist erforderlich.' }, { status: 400 });
+    }
+
+    if (!isService) {
+      return NextResponse.json(
+        {
+          error:
+            'Zum Anlegen von Abteilungen wird ein SUPABASE_SERVICE_ROLE_KEY oder passende Supabase-Policies benötigt.'
+        },
+        { status: 403 },
+      );
+    }
+
+    const { data, error } = await supabase
+      .from('departments')
+      .insert({ name: trimmedName })
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('Create department error:', error);
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('POST /departments error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resolveAdminSupabaseClient } from '@/lib/supabaseServer';
+import { SUPERUSER_EMAIL } from '@/constants/superuser';
+
+async function isTargetSuperuser(
+  supabase: Awaited<ReturnType<typeof resolveAdminSupabaseClient>>['client'],
+  userId: string,
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('email')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message ?? 'Konnte Benutzerprofil nicht laden.');
+  }
+
+  if (!data) {
+    return false;
+  }
+
+  return (data.email ?? '').toLowerCase() === SUPERUSER_EMAIL;
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const { client: supabase } = await resolveAdminSupabaseClient();
+
+  try {
+    if (await isTargetSuperuser(supabase, params.id)) {
+      return NextResponse.json(
+        { error: 'Der Superuser kann nicht bearbeitet werden.' },
+        { status: 403 },
+      );
+    }
+
+    const payload = await request.json();
+    const updates: Record<string, unknown> = {};
+
+    if ('full_name' in payload) {
+      const fullName = typeof payload.full_name === 'string' ? payload.full_name.trim() : null;
+      updates.full_name = fullName && fullName.length > 0 ? fullName : null;
+    }
+
+    if ('role' in payload) {
+      updates.role = payload.role;
+    }
+
+    if ('company' in payload) {
+      updates.company = payload.company ?? null;
+    }
+
+    if ('is_active' in payload) {
+      updates.is_active = Boolean(payload.is_active);
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'Keine Änderungen übermittelt.' }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .update(updates)
+      .eq('id', params.id)
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('Update user error:', error);
+      const errorMessage = error.message ?? '';
+
+      if (error.code === '42501' || errorMessage.toLowerCase().includes('row-level security')) {
+        return NextResponse.json(
+          {
+            error:
+              'Keine ausreichenden Rechte für diese Änderung. Bitte SUPABASE_SERVICE_ROLE_KEY konfigurieren oder passende Policies in Supabase ergänzen.'
+          },
+          { status: 403 },
+        );
+      }
+
+      return NextResponse.json({ error: errorMessage }, { status: 400 });
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('PATCH /users error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: { params: { id: string } }) {
+  const { client: supabase, isService } = await resolveAdminSupabaseClient();
+
+  if (!isService) {
+    return NextResponse.json(
+      { error: 'Benutzer löschen erfordert einen konfigurierten Supabase Service Role Key.' },
+      { status: 501 },
+    );
+  }
+
+  const userId = params.id;
+
+  try {
+    if (await isTargetSuperuser(supabase, userId)) {
+      return NextResponse.json(
+        { error: 'Der Superuser kann nicht gelöscht werden.' },
+        { status: 403 },
+      );
+    }
+
+    const { error: authError } = await supabase.auth.admin.deleteUser(userId);
+
+    if (authError && authError.message && !authError.message.toLowerCase().includes('user not found')) {
+      console.error('Delete auth user error:', authError);
+      return NextResponse.json({ error: authError.message }, { status: 400 });
+    }
+
+    const { error: profileError } = await supabase.from('profiles').delete().eq('id', userId);
+
+    if (profileError) {
+      console.error('Delete profile error:', profileError);
+      return NextResponse.json({ error: profileError.message }, { status: 400 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('DELETE /users error:', error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/boards/[boardId]/cards/route.ts
+++ b/src/app/api/boards/[boardId]/cards/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { readSessionTokens } from '@/lib/apiTokens';
+import { ensureBoardMemberAccess } from '@/lib/serverBoardAccess';
+
+interface PersistedCard {
+  board_id: string;
+  card_id: string;
+  card_data: Record<string, unknown>;
+  stage?: string | null;
+  position?: number | null;
+  project_number?: string | null;
+  project_name?: string | null;
+  updated_at?: string;
+}
+
+export async function POST(request: NextRequest, { params }: { params: { boardId: string } }) {
+  const boardId = params.boardId;
+
+  if (!boardId) {
+    return NextResponse.json({ error: 'Board-ID fehlt.' }, { status: 400 });
+  }
+
+  const tokens = readSessionTokens(request);
+  const auth = await ensureBoardMemberAccess(boardId, tokens);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch (error) {
+    console.error('Ungültige Karten-Payload:', error);
+    return NextResponse.json({ error: 'Ungültige JSON-Payload.' }, { status: 400 });
+  }
+
+  const cards = Array.isArray((payload as { cards?: PersistedCard[] }).cards)
+    ? ((payload as { cards: PersistedCard[] }).cards ?? [])
+    : [];
+
+  const timestamp = new Date().toISOString();
+  const normalizedCards = cards.map(card => ({
+    ...card,
+    board_id: boardId,
+    updated_at: timestamp,
+  }));
+
+  const { client } = auth;
+
+  const { error: deleteError } = await client.from('kanban_cards').delete().eq('board_id', boardId);
+
+  if (deleteError) {
+    const message = deleteError.message || 'Konnte bestehende Karten nicht löschen.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  if (normalizedCards.length === 0) {
+    return NextResponse.json({ success: true });
+  }
+
+  const { error: insertError } = await client.from('kanban_cards').insert(normalizedCards);
+
+  if (insertError) {
+    const message = insertError.message || 'Konnte Karten nicht speichern.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { boardId: string } }) {
+  const boardId = params.boardId;
+
+  if (!boardId) {
+    return NextResponse.json({ error: 'Board-ID fehlt.' }, { status: 400 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const cardId = searchParams.get('cardId');
+
+  if (!cardId) {
+    return NextResponse.json({ error: 'cardId ist erforderlich.' }, { status: 400 });
+  }
+
+  const tokens = readSessionTokens(request);
+  const auth = await ensureBoardMemberAccess(boardId, tokens);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  const { client } = auth;
+  const { error } = await client
+    .from('kanban_cards')
+    .delete()
+    .eq('board_id', boardId)
+    .eq('card_id', cardId);
+
+  if (error) {
+    const message = error.message || 'Konnte Karte nicht löschen.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/boards/[boardId]/settings/route.ts
+++ b/src/app/api/boards/[boardId]/settings/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { readSessionTokens } from '@/lib/apiTokens';
+import { ensureBoardMemberAccess } from '@/lib/serverBoardAccess';
+
+interface SettingsPayload {
+  settings?: Record<string, unknown> | null;
+  meta?: {
+    name?: string | null;
+    description?: string | null;
+  } | null;
+  userId?: string | null;
+}
+
+export async function GET(request: NextRequest, { params }: { params: { boardId: string } }) {
+  const boardId = params.boardId;
+
+  if (!boardId) {
+    return NextResponse.json({ error: 'Board-ID fehlt.' }, { status: 400 });
+  }
+
+  const tokens = readSessionTokens(request);
+  const auth = await ensureBoardMemberAccess(boardId, tokens, { allowViewer: true });
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const userId = searchParams.get('userId');
+
+  const { client } = auth;
+  let query = client
+    .from('kanban_board_settings')
+    .select('settings, user_id')
+    .eq('board_id', boardId)
+    .order('updated_at', { ascending: false })
+    .limit(1);
+
+  if (userId) {
+    query = query.eq('user_id', userId);
+  } else {
+    query = query.is('user_id', null);
+  }
+
+  const { data, error } = await query.maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    const message = error.message || 'Konnte Board-Einstellungen nicht laden.';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    settings: (data?.settings as Record<string, unknown> | null) ?? null,
+    userId: data?.user_id ?? userId ?? null,
+  });
+}
+
+export async function POST(request: NextRequest, { params }: { params: { boardId: string } }) {
+  const boardId = params.boardId;
+
+  if (!boardId) {
+    return NextResponse.json({ error: 'Board-ID fehlt.' }, { status: 400 });
+  }
+
+  const tokens = readSessionTokens(request);
+  const auth = await ensureBoardMemberAccess(boardId, tokens);
+  if ('response' in auth) {
+    return auth.response;
+  }
+
+  let payload: SettingsPayload;
+  try {
+    payload = (await request.json()) as SettingsPayload;
+  } catch (error) {
+    console.error('Ungültige Settings-Payload:', error);
+    return NextResponse.json({ error: 'Ungültige JSON-Payload.' }, { status: 400 });
+  }
+
+  const { client } = auth;
+  const now = new Date().toISOString();
+  const settingsDefined = Object.prototype.hasOwnProperty.call(payload, 'settings');
+  const settings = payload.settings ?? null;
+  const targetUserId = payload.userId ?? null;
+  let updatedMeta: { name?: string | null; description?: string | null; updated_at?: string | null } | null = null;
+
+  if (settingsDefined) {
+    const { error: upsertError } = await client.from('kanban_board_settings').upsert({
+      board_id: boardId,
+      user_id: targetUserId,
+      settings,
+      updated_at: now,
+    });
+
+    if (upsertError) {
+      const message = upsertError.message || 'Konnte Board-Einstellungen nicht speichern.';
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  }
+
+  if (payload.meta) {
+    const metaUpdates: Record<string, unknown> = {};
+    if ('name' in payload.meta) {
+      metaUpdates.name = payload.meta?.name ?? null;
+    }
+    if ('description' in payload.meta) {
+      metaUpdates.description = payload.meta?.description ?? null;
+    }
+
+    if (Object.keys(metaUpdates).length) {
+      const { data: boardRow, error: boardError } = await client
+        .from('kanban_boards')
+        .update({ ...metaUpdates, updated_at: now })
+        .eq('id', boardId)
+        .select('name, description, updated_at')
+        .maybeSingle();
+
+      if (boardError) {
+        const message = boardError.message || 'Konnte Board-Metadaten nicht aktualisieren.';
+        return NextResponse.json({ error: message }, { status: 500 });
+      }
+
+      if (boardRow) {
+        updatedMeta = {
+          name: boardRow.name,
+          description: boardRow.description,
+          updated_at: boardRow.updated_at,
+        };
+      } else {
+        updatedMeta = {
+          name: (metaUpdates.name as string | null | undefined) ?? null,
+          description: (metaUpdates.description as string | null | undefined) ?? null,
+          updated_at: now,
+        };
+      }
+    }
+  }
+
+  return NextResponse.json({ success: true, meta: updatedMeta });
+}

--- a/src/app/api/profiles/route.ts
+++ b/src/app/api/profiles/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { resolveAdminSupabaseClient } from '@/lib/supabaseServer';
+
+export async function GET() {
+  try {
+    const { client } = await resolveAdminSupabaseClient();
+
+    const { data, error } = await client
+      .from('profiles')
+      .select('id, email, full_name, company, role, is_active, created_at')
+      .order('full_name', { ascending: true })
+      .order('email', { ascending: true });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return NextResponse.json({ data: data ?? [] });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unbekannter Fehler beim Laden der Profile';
+    console.error('GET /api/profiles', message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,21 +1,31 @@
 'use client';
 
-import { useState } from 'react';
-import { 
-  Box, 
-  Typography, 
-  Button, 
-  Container,
-  Paper,
-  Grid,
+import { useEffect, useRef, useState } from 'react';
+import {
+  Badge,
+  Box,
+  Button,
   Card,
+  CardActions,
   CardContent,
-  CardActions
+  Container,
+  Grid,
+  IconButton,
+  Typography,
 } from '@mui/material';
-import OriginalKanbanBoard from '@/components/kanban/OriginalKanbanBoard';
+import OriginalKanbanBoard, { OriginalKanbanBoardHandle } from '@/components/kanban/OriginalKanbanBoard';
+import AssessmentIcon from '@mui/icons-material/Assessment';
 
 export default function HomePage() {
   const [selectedBoard, setSelectedBoard] = useState<string | null>(null);
+  const boardRef = useRef<OriginalKanbanBoardHandle>(null);
+  const [archivedCount, setArchivedCount] = useState<number | null>(null);
+  const [kpiCount, setKpiCount] = useState(0);
+
+  useEffect(() => {
+    setArchivedCount(null);
+    setKpiCount(0);
+  }, [selectedBoard]);
 
   // Beispiel-Boards
   const boards = [
@@ -46,29 +56,74 @@ export default function HomePage() {
     return (
       <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
         {/* Header mit Zurück-Button */}
-        <Box sx={{ 
-          p: 2, 
+        <Box sx={{
+          p: 2,
           borderBottom: '1px solid var(--line)',
           backgroundColor: 'var(--panel)',
           display: 'flex',
           alignItems: 'center',
+          justifyContent: 'space-between',
           gap: 2
         }}>
-          <Button 
-            variant="outlined" 
-            onClick={() => setSelectedBoard(null)}
-            sx={{ minWidth: 'auto' }}
-          >
-            ← Zurück
-          </Button>
-          <Typography variant="h6">
-            {boards.find(b => b.id === selectedBoard)?.name}
-          </Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Button
+              variant="outlined"
+              onClick={() => setSelectedBoard(null)}
+              sx={{ minWidth: 'auto' }}
+            >
+              ← Zurück
+            </Button>
+            <Typography variant="h6">
+              {boards.find(b => b.id === selectedBoard)?.name}
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Badge badgeContent={kpiCount} color="error">
+              <IconButton
+                onClick={() => boardRef.current?.openKpis()}
+                sx={{
+                  border: '1px solid',
+                  borderColor: 'var(--line)',
+                  width: 36,
+                  height: 36,
+                  '&:hover': { backgroundColor: 'rgba(255,255,255,0.08)' }
+                }}
+                title="KPI-Übersicht"
+              >
+                <AssessmentIcon fontSize="small" />
+              </IconButton>
+            </Badge>
+            <Button
+              variant="outlined"
+              onClick={() => boardRef.current?.openArchive()}
+              startIcon={<span>🗃️</span>}
+            >
+              Archiv{archivedCount !== null ? ` (${archivedCount})` : ' (?)'}
+            </Button>
+            <IconButton
+              onClick={() => boardRef.current?.openSettings()}
+              sx={{
+                border: '1px solid',
+                borderColor: 'var(--line)',
+                width: 36,
+                height: 36,
+                '&:hover': { backgroundColor: 'rgba(255,255,255,0.08)' }
+              }}
+              title="Board-Einstellungen"
+            >
+              ⚙️
+            </IconButton>
+          </Box>
         </Box>
 
         {/* Board */}
         <Box sx={{ flex: 1 }}>
-          <OriginalKanbanBoard boardId={selectedBoard} />
+          <OriginalKanbanBoard
+            ref={boardRef}
+            boardId={selectedBoard}
+            onArchiveCountChange={(count) => setArchivedCount(count)}
+            onKpiCountChange={(count) => setKpiCount(count)}
+          />
         </Box>
       </Box>
     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,125 +1,342 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { 
-  Box, 
-  Typography, 
-  Button, 
-  Container,
-  Paper,
-  Grid,
-  Card,
-  CardContent,
-  CardActions,
-  IconButton,
-  Fab,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
   Alert,
-  Menu,
-  MenuItem
+  Badge,
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
 } from '@mui/material';
-import OriginalKanbanBoard from '@/components/kanban/OriginalKanbanBoard';
+import OriginalKanbanBoard, { OriginalKanbanBoardHandle } from '@/components/kanban/OriginalKanbanBoard';
 import { useTheme } from '@/theme/ThemeRegistry';
 import { useAuth } from '../contexts/AuthContext';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
+import AssessmentIcon from '@mui/icons-material/Assessment';
+import BoardManagementPanel from '@/components/board/BoardManagementPanel';
+import TeamKanbanBoard from '@/components/team/TeamKanbanBoard';
+import TeamBoardManagementPanel from '@/components/team/TeamBoardManagementPanel';
+import { isSuperuserEmail } from '@/constants/superuser';
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+import SupabaseConfigNotice from '@/components/SupabaseConfigNotice';
 interface Board {
   id: string;
   name: string;
   description: string;
   created_at: string;
+  visibility?: string | null;
+  owner_id?: string | null;
+  user_id?: string | null;
   cardCount?: number;
+  settings?: Record<string, unknown> | null;
+  boardType: 'standard' | 'team';
 }
 
 export default function HomePage() {
-  const [selectedBoard, setSelectedBoard] = useState<string | null>(null);
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [selectedBoard, setSelectedBoard] = useState<Board | null>(null);
+  const [viewMode, setViewMode] = useState<'list' | 'management' | 'board' | 'team-management' | 'team-board'>('list');
   const { isDark, toggleTheme } = useTheme();
   const { user, loading, signOut } = useAuth();
-  
+  const boardRef = useRef<OriginalKanbanBoardHandle>(null);
+
   // Board Management States
   const [boards, setBoards] = useState<Board[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [isSuperuser, setIsSuperuser] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [newBoardType, setNewBoardType] = useState<'standard' | 'team'>('standard');
   const [newBoardName, setNewBoardName] = useState('');
   const [newBoardDescription, setNewBoardDescription] = useState('');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [boardToDelete, setBoardToDelete] = useState<Board | null>(null);
   const [message, setMessage] = useState('');
+  const [archivedCount, setArchivedCount] = useState<number | null>(null);
+  const [kpiCount, setKpiCount] = useState(0);
+
+  useEffect(() => {
+    setArchivedCount(null);
+    setKpiCount(0);
+  }, [selectedBoard]);
 
   // Auth-Check
   useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
     if (!loading && !user) {
       window.location.href = '/login';
     }
-  }, [user, loading]);
+  }, [loading, supabase, user]);
 
-  // Boards laden
-  useEffect(() => {
-    if (user) {
-      loadBoards();
-    }
-  }, [user]);
+  const loadProfile = useCallback(async () => {
+    if (!user || !supabase) return;
 
-  const loadBoards = async () => {
     try {
+      const superuser = isSuperuserEmail(user.email ?? null);
       const { data, error } = await supabase
-        .from('kanban_boards')
-        .select('*')
-        .order('created_at', { ascending: false });
+        .from('profiles')
+        .select('role')
+        .eq('id', user.id)
+        .maybeSingle();
 
-      if (error) throw error;
-      setBoards(data || []);
+      if (error) {
+        throw error;
+      }
+
+      const role = String(data?.role || '').toLowerCase();
+      setIsSuperuser(superuser);
+      setIsAdmin(superuser || role === 'admin');
+    } catch (error) {
+      console.error('Fehler beim Laden des Profils:', error);
+      const superuser = isSuperuserEmail(user.email ?? null);
+      setIsSuperuser(superuser);
+      setIsAdmin(superuser);
+    }
+  }, [supabase, user]);
+
+  const loadBoards = useCallback(async () => {
+    if (!supabase) {
+      setMessage('❌ Supabase-Konfiguration fehlt.');
+      return;
+    }
+    try {
+      let boardsData: Board[] | null = null;
+
+      try {
+        const { data: rpcBoards, error: rpcError } = await supabase
+          .rpc('list_all_boards');
+
+        if (rpcError) {
+          if (rpcError.code === '42883') {
+            console.warn('Supabase Funktion list_all_boards nicht gefunden. Fallback auf direkte Abfrage.');
+            if (isAdmin) {
+              setMessage('ℹ️ Bitte lege die Supabase-Funktion "list_all_boards" an, damit alle Boards für alle Nutzer sichtbar werden.');
+              setTimeout(() => setMessage(''), 6000);
+            }
+          } else {
+            console.warn('RPC list_all_boards fehlgeschlagen:', rpcError);
+          }
+        } else {
+          boardsData = (rpcBoards as Board[]) ?? [];
+        }
+      } catch (rpcUnexpectedError) {
+        console.warn('Unerwarteter RPC-Fehler:', rpcUnexpectedError);
+      }
+
+      if (!boardsData) {
+        const { data, error } = await supabase
+          .from('kanban_boards')
+          .select('*')
+          .order('created_at', { ascending: false });
+
+        if (error) throw error;
+
+        boardsData = (data as Board[]) ?? [];
+      }
+
+      const sanitizedBoards = (boardsData ?? []).map((board) => {
+        const rawSettings =
+          board && typeof board.settings === 'object' && board.settings !== null
+            ? (board.settings as Record<string, unknown>)
+            : {};
+        const typeRaw = (rawSettings as Record<string, unknown>)['boardType'];
+        const boardType = typeof typeRaw === 'string' && typeRaw.toLowerCase() === 'team' ? 'team' : 'standard';
+
+        return {
+          ...board,
+          settings: rawSettings,
+          visibility: board.visibility ?? 'public',
+          boardType,
+        } as Board;
+      });
+
+      setBoards(sanitizedBoards);
+
+      const boardsWithoutVisibility = sanitizedBoards
+        .filter((board) => !board.visibility || board.visibility === '');
+
+      if (boardsWithoutVisibility.length && isAdmin) {
+        const ids = boardsWithoutVisibility.map((board) => board.id);
+        const { error: updateError } = await supabase
+          .from('kanban_boards')
+          .update({ visibility: 'public' })
+          .in('id', ids);
+
+        if (updateError) {
+          console.error('Fehler beim Aktualisieren der Sichtbarkeit:', updateError);
+        } else {
+          setBoards((prev) =>
+            prev.map((board) =>
+              ids.includes(board.id) ? { ...board, visibility: 'public' } : board,
+            ),
+          );
+        }
+      }
     } catch (error) {
       console.error('Fehler beim Laden der Boards:', error);
       setMessage('❌ Fehler beim Laden der Boards');
     }
+  }, [isAdmin, supabase, user]);
+
+  useEffect(() => {
+    if (!user) {
+      setIsAdmin(false);
+      setIsSuperuser(false);
+      setSelectedBoard(null);
+      setViewMode('list');
+      return;
+    }
+
+    loadProfile();
+    loadBoards();
+  }, [user, loadProfile, loadBoards]);
+
+  useEffect(() => {
+    const handleBoardMetaUpdated = (event: Event) => {
+      const { id, name, description } = (event as CustomEvent<{
+        id?: string;
+        name?: string | null;
+        description?: string | null;
+      }>).detail || {};
+
+      if (!id) return;
+
+      setBoards((prev) =>
+        prev.map((board) =>
+          board.id === id
+            ? {
+                ...board,
+                ...(name !== undefined ? { name: name ?? board.name } : {}),
+                ...(description !== undefined
+                  ? { description: description ?? board.description }
+                  : {}),
+              }
+            : board,
+        ),
+      );
+
+      setSelectedBoard((prev) =>
+        prev && prev.id === id
+          ? {
+              ...prev,
+              ...(name !== undefined ? { name: name ?? prev.name } : {}),
+              ...(description !== undefined
+                ? { description: description ?? prev.description }
+                : {}),
+            }
+          : prev,
+      );
+    };
+
+    window.addEventListener('board-meta-updated', handleBoardMetaUpdated as EventListener);
+
+    return () => {
+      window.removeEventListener('board-meta-updated', handleBoardMetaUpdated as EventListener);
+    };
+  }, []);
+
+  const standardBoards = useMemo(() => boards.filter((board) => board.boardType === 'standard'), [boards]);
+  const teamBoards = useMemo(() => boards.filter((board) => board.boardType === 'team'), [boards]);
+
+  const createBoard = async () => {
+    if (!supabase) {
+      setMessage('❌ Supabase-Konfiguration fehlt.');
+      return;
+    }
+
+    if (!newBoardName.trim()) return;
+
+    if (!isAdmin) {
+      setMessage('❌ Nur Administratoren können neue Boards erstellen.');
+      setTimeout(() => setMessage(''), 3000);
+      return;
+    }
+
+    try {
+      const initialSettings = { boardType: newBoardType };
+      const { data, error } = await supabase
+        .from('kanban_boards')
+        .insert([
+          {
+            name: newBoardName.trim(),
+            description: newBoardDescription.trim(),
+            owner_id: user?.id,
+            user_id: user?.id,
+            visibility: 'public',
+            settings: initialSettings,
+          },
+        ])
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      if (data) {
+        const rawSettings =
+          typeof data.settings === 'object' && data.settings !== null
+            ? (data.settings as Record<string, unknown>)
+            : initialSettings;
+        const typeRaw = (rawSettings as Record<string, unknown>)['boardType'];
+        const boardType = typeof typeRaw === 'string' && typeRaw.toLowerCase() === 'team' ? 'team' : 'standard';
+        const base = data as Record<string, unknown>;
+        const createdBoard: Board = {
+          id: String(base['id']),
+          name: String(base['name'] ?? newBoardName.trim()),
+          description: (base['description'] as string) ?? newBoardDescription.trim(),
+          created_at: String(base['created_at'] ?? new Date().toISOString()),
+          visibility: (base['visibility'] as string) ?? 'public',
+          owner_id: (base['owner_id'] as string | null) ?? null,
+          user_id: (base['user_id'] as string | null) ?? null,
+          cardCount: typeof base['cardCount'] === 'number' ? (base['cardCount'] as number) : undefined,
+          settings: rawSettings,
+          boardType,
+        };
+
+        setBoards((prev) => [createdBoard, ...prev]);
+      }
+
+      setCreateDialogOpen(false);
+      setNewBoardName('');
+      setNewBoardDescription('');
+      setNewBoardType('standard');
+      setMessage('✅ Board erfolgreich erstellt!');
+
+      setTimeout(() => setMessage(''), 3000);
+    } catch (error) {
+      console.error('Fehler beim Erstellen:', error);
+      setMessage('❌ Fehler beim Erstellen des Boards');
+    }
   };
 
-const createBoard = async () => {
-  if (!newBoardName.trim()) return;
-
-  try {
-    const { data, error } = await supabase
-      .from('kanban_boards')
-      .insert([
-        {
-          name: newBoardName.trim(),
-          description: newBoardDescription.trim(),
-          owner_id: user?.id,
-          user_id: user?.id,  // Für Rückwärtskompatibilität
-          visibility: 'private',
-          settings: {}
-        }
-      ])
-      .select()
-      .single();
-
-    if (error) throw error;
-
-    setBoards([data, ...boards]);
-    setCreateDialogOpen(false);
-    setNewBoardName('');
-    setNewBoardDescription('');
-    setMessage('✅ Board erfolgreich erstellt!');
-    
-    setTimeout(() => setMessage(''), 3000);
-  } catch (error) {
-    console.error('Fehler beim Erstellen:', error);
-    setMessage('❌ Fehler beim Erstellen des Boards');
-  }
-};
-
-
   const deleteBoard = async () => {
+    if (!supabase) {
+      setMessage('❌ Supabase-Konfiguration fehlt.');
+      return;
+    }
+
     if (!boardToDelete) return;
+
+    if (!isAdmin) {
+      setMessage('❌ Nur Administratoren können Boards löschen.');
+      setTimeout(() => setMessage(''), 3000);
+      return;
+    }
 
     try {
       const { error } = await supabase
@@ -129,11 +346,11 @@ const createBoard = async () => {
 
       if (error) throw error;
 
-      setBoards(boards.filter(b => b.id !== boardToDelete.id));
+      setBoards((prev) => prev.filter(b => b.id !== boardToDelete.id));
       setDeleteDialogOpen(false);
       setBoardToDelete(null);
       setMessage('✅ Board erfolgreich gelöscht!');
-      
+
       setTimeout(() => setMessage(''), 3000);
     } catch (error) {
       console.error('Fehler beim Löschen:', error);
@@ -149,6 +366,14 @@ const createBoard = async () => {
     );
   }
 
+  if (!supabase) {
+    return (
+      <Container maxWidth="sm" sx={{ py: 8 }}>
+        <SupabaseConfigNotice />
+      </Container>
+    );
+  }
+
   if (!user) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
@@ -158,66 +383,274 @@ const createBoard = async () => {
   }
 
   // Board-Ansicht
-  if (selectedBoard) {
-    const currentBoard = boards.find(b => b.id === selectedBoard);
+  if (selectedBoard && selectedBoard.boardType === 'standard' && viewMode === 'board') {
     return (
       <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-        {/* Header */}
-        <Box sx={{ 
-          p: 2, 
-          borderBottom: 1,
-          borderColor: 'divider',
-          backgroundColor: 'background.paper',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between'
-        }}>
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: 1,
+            borderColor: 'divider',
+            backgroundColor: 'background.paper',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <Button 
-              variant="outlined" 
-              onClick={() => setSelectedBoard(null)}
-            >
-              ← Zurück
+            <Button variant="outlined" onClick={() => setViewMode('management')}>
+              ← Management
             </Button>
-            <Typography variant="h6">
-              {currentBoard?.name || 'Board'}
-            </Typography>
+            <Typography variant="h6">{selectedBoard.name || 'Board'}</Typography>
           </Box>
-          
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-  <Button 
-    variant="outlined" 
-    onClick={() => window.location.href = '/admin'}
-    sx={{ 
-      color: '#9c27b0', 
-      borderColor: '#9c27b0',
-      '&:hover': {
-        backgroundColor: '#f3e5f5',
-        borderColor: '#7b1fa2'
-      }
-    }}
-  >
-   
-    👥 Admin
-  </Button>
-  <Typography variant="body2">
-    👋 {user.email}
-  </Typography>
-  <IconButton onClick={toggleTheme} color="primary">
-    {isDark ? '☀️' : '🌙'}
-  </IconButton>
-  <Button variant="outlined" onClick={signOut} color="error">
-    🚪 Abmelden
-  </Button>
-</Box>
 
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Badge badgeContent={kpiCount} color="error" overlap="circular">
+              <IconButton
+                onClick={() => boardRef.current?.openKpis()}
+                sx={{
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  width: 36,
+                  height: 36,
+                  '&:hover': { backgroundColor: 'action.hover' },
+                }}
+                title="KPI-Übersicht öffnen"
+              >
+                <AssessmentIcon fontSize="small" />
+              </IconButton>
+            </Badge>
+            <Button
+              variant="outlined"
+              onClick={() => boardRef.current?.openArchive()}
+              startIcon={<span>🗃️</span>}
+              sx={{ whiteSpace: 'nowrap' }}
+            >
+              Archiv{archivedCount !== null ? ` (${archivedCount})` : ' (?)'}
+            </Button>
+            <IconButton
+              onClick={() => boardRef.current?.openSettings()}
+              sx={{
+                border: '1px solid',
+                borderColor: 'divider',
+                width: 36,
+                height: 36,
+                '&:hover': { backgroundColor: 'action.hover' },
+              }}
+              title="Board-Einstellungen"
+            >
+              ⚙️
+            </IconButton>
+            <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+              👋 {user.email}
+            </Typography>
+            <IconButton onClick={toggleTheme} color="primary">
+              {isDark ? '☀️' : '🌙'}
+            </IconButton>
+            <Button variant="outlined" onClick={signOut} color="error">
+              🚪 Abmelden
+            </Button>
+          </Box>
         </Box>
 
-        {/* Board */}
         <Box sx={{ flex: 1 }}>
-          <OriginalKanbanBoard boardId={selectedBoard} />
+          <OriginalKanbanBoard
+            ref={boardRef}
+            boardId={selectedBoard.id}
+            onArchiveCountChange={(count) => setArchivedCount(count)}
+            onKpiCountChange={(count) => setKpiCount(count)}
+          />
         </Box>
       </Box>
+    );
+  }
+
+  if (selectedBoard && selectedBoard.boardType === 'standard' && viewMode === 'management') {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 2,
+            mb: 3,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+            <Button variant="outlined" onClick={() => { setSelectedBoard(null); setViewMode('list'); }}>
+              ← Übersicht
+            </Button>
+            <Box>
+              <Typography variant="h5">{selectedBoard.name}</Typography>
+              {selectedBoard.description && (
+                <Typography variant="body2" color="text.secondary">
+                  {selectedBoard.description}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Button
+              variant="contained"
+              onClick={() => setViewMode('board')}
+              sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}
+            >
+              📋 Zum Board
+            </Button>
+            {isAdmin && (
+              <Button
+                variant="outlined"
+                onClick={() => (window.location.href = '/admin')}
+                sx={{
+                  color: '#9c27b0',
+                  borderColor: '#9c27b0',
+                  '&:hover': {
+                    backgroundColor: '#f3e5f5',
+                    borderColor: '#7b1fa2',
+                  },
+                }}
+              >
+                👥 Admin
+              </Button>
+            )}
+            <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+              👋 {user.email}
+            </Typography>
+            <IconButton onClick={toggleTheme} color="primary">
+              {isDark ? '☀️' : '🌙'}
+            </IconButton>
+            <Button variant="outlined" onClick={signOut} color="error">
+              🚪 Abmelden
+            </Button>
+          </Box>
+        </Box>
+
+        <BoardManagementPanel
+          boardId={selectedBoard.id}
+          canEdit={isAdmin || isSuperuser}
+          memberCanSee={true}
+        />
+      </Container>
+    );
+  }
+
+  if (selectedBoard && selectedBoard.boardType === 'team' && viewMode === 'team-board') {
+    return (
+      <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: 1,
+            borderColor: 'divider',
+            backgroundColor: 'background.paper',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 2,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Button variant="outlined" onClick={() => setViewMode('team-management')}>
+              ← Management
+            </Button>
+            <Typography variant="h6">{selectedBoard.name || 'Teamboard'}</Typography>
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+              👋 {user.email}
+            </Typography>
+            <IconButton onClick={toggleTheme} color="primary">
+              {isDark ? '☀️' : '🌙'}
+            </IconButton>
+            <Button variant="outlined" onClick={signOut} color="error">
+              🚪 Abmelden
+            </Button>
+          </Box>
+        </Box>
+
+        <Box sx={{ flex: 1, overflow: 'hidden' }}>
+          <TeamKanbanBoard boardId={selectedBoard.id} />
+        </Box>
+      </Box>
+    );
+  }
+
+  if (selectedBoard && selectedBoard.boardType === 'team' && viewMode === 'team-management') {
+    return (
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 2,
+            mb: 3,
+          }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+            <Button variant="outlined" onClick={() => { setSelectedBoard(null); setViewMode('list'); }}>
+              ← Übersicht
+            </Button>
+            <Box>
+              <Typography variant="h5">{selectedBoard.name}</Typography>
+              {selectedBoard.description && (
+                <Typography variant="body2" color="text.secondary">
+                  {selectedBoard.description}
+                </Typography>
+              )}
+            </Box>
+          </Box>
+
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexWrap: 'wrap' }}>
+            <Button
+              variant="contained"
+              onClick={() => setViewMode('team-board')}
+              sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}
+            >
+              📋 Zum Board
+            </Button>
+            {isAdmin && (
+              <Button
+                variant="outlined"
+                onClick={() => (window.location.href = '/admin')}
+                sx={{
+                  color: '#9c27b0',
+                  borderColor: '#9c27b0',
+                  '&:hover': {
+                    backgroundColor: '#f3e5f5',
+                    borderColor: '#7b1fa2',
+                  },
+                }}
+              >
+                👥 Admin
+              </Button>
+            )}
+            <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>
+              👋 {user.email}
+            </Typography>
+            <IconButton onClick={toggleTheme} color="primary">
+              {isDark ? '☀️' : '🌙'}
+            </IconButton>
+            <Button variant="outlined" onClick={signOut} color="error">
+              🚪 Abmelden
+            </Button>
+          </Box>
+        </Box>
+
+        <TeamBoardManagementPanel
+          boardId={selectedBoard.id}
+          canEdit={isAdmin || isSuperuser}
+          memberCanSee={true}
+        />
+      </Container>
     );
   }
 
@@ -225,31 +658,31 @@ const createBoard = async () => {
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       {/* Header */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-  <Button 
-    variant="outlined" 
-    onClick={() => window.location.href = '/admin'}
-    sx={{ 
-      color: '#9c27b0', 
-      borderColor: '#9c27b0',
-      '&:hover': {
-        backgroundColor: '#f3e5f5',
-        borderColor: '#7b1fa2'
-      }
-    }}
-  >
-    👥 Admin
-  </Button>
-  <Typography variant="body2">
-    👋 {user.email}
-  </Typography>
-  <IconButton onClick={toggleTheme} color="primary">
-    {isDark ? '☀️' : '🌙'}
-  </IconButton>
-  <Button variant="outlined" onClick={signOut} color="error">
-    🚪 Abmelden
-  </Button>
-</Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+        {isAdmin && (
+          <Button
+            variant="outlined"
+            onClick={() => (window.location.href = '/admin')}
+            sx={{
+              color: '#9c27b0',
+              borderColor: '#9c27b0',
+              '&:hover': {
+                backgroundColor: '#f3e5f5',
+                borderColor: '#7b1fa2',
+              },
+            }}
+          >
+            👥 Admin
+          </Button>
+        )}
+        <Typography variant="body2">👋 {user.email}</Typography>
+        <IconButton onClick={toggleTheme} color="primary">
+          {isDark ? '☀️' : '🌙'}
+        </IconButton>
+        <Button variant="outlined" onClick={signOut} color="error">
+          🚪 Abmelden
+        </Button>
+      </Box>
       {/* Message */}
       {message && (
         <Alert severity={message.startsWith('✅') ? 'success' : 'error'} sx={{ mb: 3 }}>
@@ -257,33 +690,39 @@ const createBoard = async () => {
         </Alert>
       )}
 
-      {/* Boards Grid */}
+      {/* Standard Boards */}
+      <Typography variant="h5" sx={{ mt: 2, mb: 2 }}>
+        Projektboards
+      </Typography>
       <Grid container spacing={3}>
-        {/* Neues Board erstellen */}
-        <Grid item xs={12} sm={6} md={4}>
-          <Card 
-            sx={{ 
-              height: 200, 
-              display: 'flex', 
-              alignItems: 'center', 
-              justifyContent: 'center',
-              border: '2px dashed #ccc',
-              cursor: 'pointer',
-              '&:hover': { borderColor: '#14c38e' }
-            }}
-            onClick={() => setCreateDialogOpen(true)}
-          >
-            <Box sx={{ textAlign: 'center' }}>
-              <Typography variant="h1" sx={{ fontSize: 48, color: '#ccc' }}>+</Typography>
-              <Typography variant="h6" color="text.secondary">
-                Neues Board erstellen
-              </Typography>
-            </Box>
-          </Card>
-        </Grid>
+        {isAdmin && (
+          <Grid item xs={12} sm={6} md={4}>
+            <Card
+              sx={{
+                height: 200,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: '2px dashed #ccc',
+                cursor: 'pointer',
+                '&:hover': { borderColor: '#14c38e' },
+              }}
+              onClick={() => {
+                setNewBoardType('standard');
+                setCreateDialogOpen(true);
+              }}
+            >
+              <Box sx={{ textAlign: 'center' }}>
+                <Typography variant="h1" sx={{ fontSize: 48, color: '#ccc' }}>+</Typography>
+                <Typography variant="h6" color="text.secondary">
+                  Neues Projektboard
+                </Typography>
+              </Box>
+            </Card>
+          </Grid>
+        )}
 
-        {/* Bestehende Boards */}
-        {boards.map((board) => (
+        {standardBoards.map((board) => (
           <Grid item xs={12} sm={6} md={4} key={board.id}>
             <Card sx={{ height: 200, display: 'flex', flexDirection: 'column' }}>
               <CardContent sx={{ flex: 1 }}>
@@ -298,33 +737,140 @@ const createBoard = async () => {
                 </Typography>
               </CardContent>
               <CardActions sx={{ justifyContent: 'space-between' }}>
-                <Button 
-                  size="small" 
+                <Button
+                  size="small"
                   variant="contained"
-                  onClick={() => setSelectedBoard(board.id)}
+                  onClick={() => {
+                    setSelectedBoard(board);
+                    setViewMode('management');
+                  }}
                   sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}
                 >
                   📋 Öffnen
                 </Button>
-                <Button 
-                  size="small" 
-                  color="error"
-                  onClick={() => {
-                    setBoardToDelete(board);
-                    setDeleteDialogOpen(true);
-                  }}
-                >
-                  🗑️ Löschen
-                </Button>
+                {isAdmin && (
+                  <Button
+                    size="small"
+                    color="error"
+                    onClick={() => {
+                      setBoardToDelete(board);
+                      setDeleteDialogOpen(true);
+                    }}
+                  >
+                    🗑️ Löschen
+                  </Button>
+                )}
               </CardActions>
             </Card>
           </Grid>
         ))}
+
+        {standardBoards.length === 0 && !isAdmin && (
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="body2" color="text.secondary">
+                  Es sind noch keine Projektboards vorhanden.
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+      </Grid>
+
+      {/* Team Boards */}
+      <Typography variant="h5" sx={{ mt: 5, mb: 2 }}>
+        Teamboards
+      </Typography>
+      <Grid container spacing={3}>
+        {isAdmin && (
+          <Grid item xs={12} sm={6} md={4}>
+            <Card
+              sx={{
+                height: 200,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: '2px dashed #ccc',
+                cursor: 'pointer',
+                '&:hover': { borderColor: '#14c38e' },
+              }}
+              onClick={() => {
+                setNewBoardType('team');
+                setCreateDialogOpen(true);
+              }}
+            >
+              <Box sx={{ textAlign: 'center' }}>
+                <Typography variant="h1" sx={{ fontSize: 48, color: '#ccc' }}>+</Typography>
+                <Typography variant="h6" color="text.secondary">
+                  Neues Teamboard
+                </Typography>
+              </Box>
+            </Card>
+          </Grid>
+        )}
+
+        {teamBoards.map((board) => (
+          <Grid item xs={12} sm={6} md={4} key={board.id}>
+            <Card sx={{ height: 200, display: 'flex', flexDirection: 'column' }}>
+              <CardContent sx={{ flex: 1 }}>
+                <Typography variant="h6" component="h2" gutterBottom>
+                  {board.name}
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  {board.description || 'Keine Beschreibung'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Erstellt: {new Date(board.created_at).toLocaleDateString('de-DE')}
+                </Typography>
+              </CardContent>
+              <CardActions sx={{ justifyContent: 'space-between' }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={() => {
+                    setSelectedBoard(board);
+                    setViewMode('team-management');
+                  }}
+                  sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}
+                >
+                  📋 Öffnen
+                </Button>
+                {isAdmin && (
+                  <Button
+                    size="small"
+                    color="error"
+                    onClick={() => {
+                      setBoardToDelete(board);
+                      setDeleteDialogOpen(true);
+                    }}
+                  >
+                    🗑️ Löschen
+                  </Button>
+                )}
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+
+        {teamBoards.length === 0 && !isAdmin && (
+          <Grid item xs={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="body2" color="text.secondary">
+                  Es sind noch keine Teamboards vorhanden.
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
       </Grid>
 
       {/* Create Board Dialog */}
-      <Dialog open={createDialogOpen} onClose={() => setCreateDialogOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>🆕 Neues Board erstellen</DialogTitle>
+      <Dialog open={createDialogOpen} onClose={() => { setCreateDialogOpen(false); setNewBoardType('standard'); }} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          🆕 Neues {newBoardType === 'team' ? 'Teamboard' : 'Projektboard'} erstellen
+        </DialogTitle>
         <DialogContent>
           <TextField
             autoFocus
@@ -336,6 +882,17 @@ const createBoard = async () => {
             onChange={(e) => setNewBoardName(e.target.value)}
             sx={{ mb: 2 }}
           />
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel>Kategorie</InputLabel>
+            <Select
+              label="Kategorie"
+              value={newBoardType}
+              onChange={(event) => setNewBoardType(event.target.value as 'standard' | 'team')}
+            >
+              <MenuItem value="standard">Projektboard</MenuItem>
+              <MenuItem value="team">Teamboard</MenuItem>
+            </Select>
+          </FormControl>
           <TextField
             margin="dense"
             label="Beschreibung (optional)"
@@ -348,11 +905,16 @@ const createBoard = async () => {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setCreateDialogOpen(false)}>
+          <Button
+            onClick={() => {
+              setCreateDialogOpen(false);
+              setNewBoardType('standard');
+            }}
+          >
             Abbrechen
           </Button>
-          <Button 
-            onClick={createBoard} 
+          <Button
+            onClick={createBoard}
             variant="contained"
             disabled={!newBoardName.trim()}
             sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}

--- a/src/components/SupabaseConfigNotice.tsx
+++ b/src/components/SupabaseConfigNotice.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Alert, AlertTitle, Box, Link, Typography } from '@mui/material';
+
+interface SupabaseConfigNoticeProps {
+  title?: string;
+  description?: string;
+  hintUrl?: string;
+}
+
+const DEFAULT_DESCRIPTION =
+  'Bitte hinterlege die Umgebungsvariablen NEXT_PUBLIC_SUPABASE_URL und NEXT_PUBLIC_SUPABASE_ANON_KEY, ' +
+  'damit die Anwendung eine Verbindung zu Supabase aufbauen kann.';
+
+export default function SupabaseConfigNotice({
+  title = 'Supabase-Konfiguration fehlt',
+  description = DEFAULT_DESCRIPTION,
+  hintUrl,
+}: SupabaseConfigNoticeProps) {
+  return (
+    <Box sx={{ width: '100%', maxWidth: 640, mx: 'auto', mt: 6 }}>
+      <Alert severity="error" variant="filled" sx={{ alignItems: 'flex-start' }}>
+        <AlertTitle>{title}</AlertTitle>
+        <Typography component="p" sx={{ mb: hintUrl ? 1.5 : 0 }}>
+          {description}
+        </Typography>
+        {hintUrl ? (
+          <Typography component="p">
+            <Link href={hintUrl} target="_blank" rel="noreferrer" sx={{ color: 'inherit', textDecoration: 'underline' }}>
+              Weitere Informationen anzeigen
+            </Link>
+          </Typography>
+        ) : null}
+      </Alert>
+    </Box>
+  );
+}

--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -1,20 +1,42 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Box, Typography, Container, Card, CardContent, Grid,
-  Avatar, Chip, Button, Dialog, DialogTitle, DialogContent,
-  DialogActions, TextField, Select, MenuItem, FormControl,
-  InputLabel, Alert, Table, TableBody, TableCell, TableContainer,
-  TableHead, TableRow, Paper
+  Box,
+  Typography,
+  Container,
+  Card,
+  CardContent,
+  Grid,
+  Avatar,
+  Chip,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Alert,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Switch,
+  Stack,
+  Tooltip,
+  IconButton
 } from '@mui/material';
-import { createClient } from '@supabase/supabase-js';
-import { useAuth } from '../../contexts/AuthContext';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+import DeleteIcon from '@mui/icons-material/Delete';
+import { isSuperuserEmail } from '@/constants/superuser';
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+import SupabaseConfigNotice from '@/components/SupabaseConfigNotice';
 
 interface UserProfile {
   id: string;
@@ -22,201 +44,373 @@ interface UserProfile {
   full_name: string;
   avatar_url?: string;
   bio?: string;
-  company?: string;
+  company?: string | null;
   role: string;
   is_active: boolean;
   created_at: string;
 }
 
-interface Team {
+interface Department {
   id: string;
   name: string;
-  description?: string;
-  member_count: number;
-  created_at: string;
+  created_at?: string;
+}
+
+function normalizeUserProfile(profile: any): UserProfile {
+  return {
+    id: profile.id,
+    email: profile.email ?? '',
+    full_name: profile.full_name ?? '',
+    avatar_url: profile.avatar_url ?? undefined,
+    bio: profile.bio ?? undefined,
+    company: profile.company ?? null,
+    role: profile.role ?? 'user',
+    is_active: profile.is_active ?? true,
+    created_at: profile.created_at ?? '',
+  };
 }
 
 export default function UserManagement() {
-  const { user } = useAuth();
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+
+  if (!supabase) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <SupabaseConfigNotice />
+      </Box>
+    );
+  }
+
   const [users, setUsers] = useState<UserProfile[]>([]);
-  const [teams, setTeams] = useState<Team[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
   const [loading, setLoading] = useState(true);
-  const [createTeamDialogOpen, setCreateTeamDialogOpen] = useState(false);
-  const [newTeamName, setNewTeamName] = useState('');
-  const [newTeamDescription, setNewTeamDescription] = useState('');
   const [message, setMessage] = useState('');
 
-  
   const [createUserDialogOpen, setCreateUserDialogOpen] = useState(false);
   const [newUserEmail, setNewUserEmail] = useState('');
   const [newUserPassword, setNewUserPassword] = useState('');
-useEffect(() => {
+  const [newUserName, setNewUserName] = useState('');
+  const [newUserDepartment, setNewUserDepartment] = useState('');
+  const [editableNames, setEditableNames] = useState<Record<string, string>>({});
+
+  const [departmentDialogOpen, setDepartmentDialogOpen] = useState(false);
+  const [newDepartmentName, setNewDepartmentName] = useState('');
+
+  const postJson = useMemo(() => ({ 'Content-Type': 'application/json' }), []);
+
+  const isProtectedUser = (userId: string): boolean => {
+    const profile = users.find(entry => entry.id === userId);
+    return isSuperuserEmail(profile?.email);
+  };
+
+  const guardSuperuser = (userId: string): boolean => {
+    if (isProtectedUser(userId)) {
+      setMessage('❌ Der Superuser kann nicht bearbeitet werden.');
+      setTimeout(() => setMessage(''), 4000);
+      return true;
+    }
+
+    return false;
+  };
+
+  useEffect(() => {
     loadData();
   }, []);
 
-const loadData = async () => {
-  try {
-    console.log('🔍 Starte Daten-Laden...');
+  const loadData = async () => {
+    try {
+      setLoading(true);
 
-    // Alle User laden
-    const { data: usersData, error: usersError } = await supabase
-      .from('profiles')
-      .select('*')
-      .order('created_at', { ascending: false });
+      const [usersResult, departmentsResult] = await Promise.all([
+        supabase
+          .from('profiles')
+          .select('*')
+          .order('created_at', { ascending: false }),
+        supabase
+          .from('departments')
+          .select('*')
+          .order('name')
+      ]);
 
-    console.log('👥 Users geladen:', usersData?.length || 0);
+      const { data: usersData, error: usersError } = usersResult;
+      if (usersError) {
+        console.error('❌ Users Error:', usersError);
+        setMessage(`❌ User-Fehler: ${usersError.message}`);
+        setUsers([]);
+      } else {
+        const normalizedUsers = ((usersData as any[]) ?? []).map(normalizeUserProfile);
+        setUsers(normalizedUsers);
+        const mappedNames: Record<string, string> = {};
+        normalizedUsers.forEach(profile => {
+          mappedNames[profile.id] = profile.full_name || '';
+        });
+        setEditableNames(mappedNames);
+      }
 
-    if (usersError) {
-      console.error('❌ Users Error:', usersError);
-      setMessage(`❌ User-Fehler: ${usersError.message}`);
-      setUsers([]);
-    } else {
-      setUsers(usersData || []);
+      const { data: departmentsData, error: departmentsError } = departmentsResult;
+      if (departmentsError) {
+        console.error('❌ Departments Error:', departmentsError);
+        if (departmentsError.code === '42P01') {
+          setMessage('❌ Tabelle "departments" nicht gefunden. Bitte in Supabase anlegen.');
+        } else {
+          setMessage(`❌ Abteilungs-Fehler: ${departmentsError.message}`);
+        }
+        setDepartments([]);
+      } else {
+        setDepartments(departmentsData || []);
+      }
+    } catch (error) {
+      console.error('💥 Unerwarteter Fehler:', error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      setMessage(`❌ Unerwarteter Fehler: ${errorMessage}`);
+    } finally {
+      setLoading(false);
     }
+  };
 
-    // Teams laden (einfacher)
-    const { data: teamsData, error: teamsError } = await supabase
-      .from('teams')
-      .select('*')
-      .order('created_at', { ascending: false });
+  const mutateUser = async (
+    userId: string,
+    payload: Partial<Pick<UserProfile, 'full_name' | 'role' | 'company' | 'is_active'>>,
+    successMessage: string,
+  ) => {
+    try {
+      const response = await fetch(`/api/admin/users/${userId}`, {
+        method: 'PATCH',
+        headers: postJson,
+        body: JSON.stringify(payload),
+      });
 
-    console.log('🏢 Teams geladen:', teamsData?.length || 0);
+      if (!response.ok) {
+        const { error: errorMessage } = await response.json();
+        throw new Error(errorMessage ?? 'Unbekannter Fehler');
+      }
 
-    if (teamsError) {
-      console.error('❌ Teams Error:', teamsError);
-      setMessage(`❌ Team-Fehler: ${teamsError.message}`);
-      setTeams([]);
-    } else {
-      // Vereinfachte Teams (ohne Member-Count erstmal)
-      const teamsWithCounts = teamsData?.map(team => ({
-        ...team,
-        member_count: 0 // Erstmal 0, später können wir das richtig machen
-      })) || [];
-      
-      setTeams(teamsWithCounts);
+      const { data } = await response.json();
+
+      setUsers(prev =>
+        prev.map(profile => {
+          if (profile.id !== userId) {
+            return profile;
+          }
+
+          if (data) {
+            return normalizeUserProfile({ ...profile, ...data });
+          }
+
+          return normalizeUserProfile({ ...profile, ...payload });
+        }),
+      );
+
+      if ('full_name' in payload) {
+        const updatedName =
+          typeof payload.full_name === 'string'
+            ? payload.full_name
+            : (data?.full_name as string | null) ?? '';
+        setEditableNames(prev => ({ ...prev, [userId]: updatedName ?? '' }));
+      }
+
+      setMessage(`✅ ${successMessage}`);
+      setTimeout(() => setMessage(''), 3000);
+    } catch (error) {
+      console.error('Benutzeraktualisierung fehlgeschlagen:', error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Fehler beim Aktualisieren der Benutzerdaten';
+      setMessage(`❌ ${message}`);
+      setTimeout(() => setMessage(''), 4000);
     }
-
-    console.log('✅ Daten-Laden abgeschlossen');
-
-  } catch (error) {
-    console.error('💥 Unerwarteter Fehler:', error);
-    setMessage(`❌ Unerwarteter Fehler: ${error.message}`);
-  } finally {
-    setLoading(false);
-  }
-};
-
-
+  };
 
   const updateUserRole = async (userId: string, newRole: string) => {
-    try {
-      const { error } = await supabase
-        .from('profiles')
-        .update({ role: newRole })
-        .eq('id', userId);
-
-      if (error) throw error;
-
-      setMessage('✅ Benutzerrolle erfolgreich aktualisiert!');
-      loadData();
-      setTimeout(() => setMessage(''), 3000);
-    } catch (error) {
-      console.error('Fehler beim Aktualisieren:', error);
-      setMessage('❌ Fehler beim Aktualisieren der Rolle');
+    if (guardSuperuser(userId)) {
+      return;
     }
+
+    await mutateUser(userId, { role: newRole }, 'Benutzerrolle erfolgreich aktualisiert!');
   };
 
-  const createTeam = async () => {
-    if (!newTeamName.trim()) return;
-
-    try {
-      const inviteCode = Math.random().toString(36).substring(2, 15);
-
-      const { data, error } = await supabase
-        .from('teams')
-        .insert([
-          {
-            name: newTeamName.trim(),
-            description: newTeamDescription.trim(),
-            invite_code: inviteCode,
-            created_by: user?.id
-          }
-        ])
-        .select()
-        .single();
-
-      if (error) throw error;
-
-      // Ersteller als Owner hinzufügen
-      await supabase
-        .from('team_members')
-        .insert([
-          {
-            team_id: data.id,
-            user_id: user?.id,
-            role: 'owner'
-          }
-        ]);
-
-      setCreateTeamDialogOpen(false);
-      setNewTeamName('');
-      setNewTeamDescription('');
-      setMessage('✅ Team erfolgreich erstellt!');
-      loadData();
-      setTimeout(() => setMessage(''), 3000);
-    } catch (error) {
-      console.error('Fehler beim Erstellen:', error);
-      setMessage('❌ Fehler beim Erstellen des Teams');
+  const updateUserDepartment = async (userId: string, departmentName: string) => {
+    if (guardSuperuser(userId)) {
+      return;
     }
+
+    await mutateUser(
+      userId,
+      { company: departmentName || null },
+      'Abteilung erfolgreich aktualisiert!',
+    );
   };
 
-const createUser = async () => {
-  if (!newUserEmail.trim() || !newUserPassword.trim()) return;
-  try {
-    const { data, error } = await supabase.auth.signUp({
-      email: newUserEmail.trim(),
-      password: newUserPassword.trim()
-    });
-    if (error) throw error;
+  const updateUserName = async (userId: string, fullName: string) => {
+    if (guardSuperuser(userId)) {
+      return;
+    }
 
-    if (data.user?.id) {
-      await supabase.from('profiles').insert({
-        id: data.user.id,
-        email: newUserEmail.trim(),
-        role: 'user',
-        is_active: true
+    const trimmed = fullName.trim();
+    if (!trimmed) {
+      const fallbackName = users.find(profile => profile.id === userId)?.full_name || '';
+      setEditableNames(prev => ({ ...prev, [userId]: fallbackName }));
+      setMessage('❌ Name darf nicht leer sein.');
+      setTimeout(() => setMessage(''), 3000);
+      return;
+    }
+
+    await mutateUser(userId, { full_name: trimmed }, 'Benutzername erfolgreich aktualisiert!');
+  };
+
+  const handleInlineNameChange = (userId: string, value: string) => {
+    setEditableNames(prev => ({ ...prev, [userId]: value }));
+  };
+
+  const toggleUserActive = async (userId: string, currentState: boolean | null | undefined) => {
+    if (guardSuperuser(userId)) {
+      return;
+    }
+
+    await mutateUser(
+      userId,
+      { is_active: !(currentState ?? true) },
+      `Benutzer ${(currentState ?? true) ? 'deaktiviert' : 'reaktiviert'}!`,
+    );
+  };
+
+  const deleteUser = async (userId: string) => {
+    if (guardSuperuser(userId)) {
+      return;
+    }
+
+    if (!window.confirm('Benutzer wirklich löschen? Dies kann nicht rückgängig gemacht werden.')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/admin/users/${userId}`, {
+        method: 'DELETE',
       });
-    }
 
-    setCreateUserDialogOpen(false);
-    setNewUserEmail('');
-    setNewUserPassword('');
-    setMessage('✅ Benutzer erfolgreich erstellt!');
-    loadData();
-    setTimeout(() => setMessage(''), 3000);
-  } catch (err: any) {
-    console.error('Fehler beim Benutzer anlegen:', err);
-    setMessage(`❌ Fehler beim Erstellen: ${err.message ?? err}`);
-  }
-};
+      if (!response.ok) {
+        const { error } = await response.json();
+        throw new Error(error ?? 'Fehler beim Löschen des Benutzers');
+      }
 
+      setUsers(prev => prev.filter(user => user.id !== userId));
+      setEditableNames(prev => {
+        const next = { ...prev };
+        delete next[userId];
+        return next;
+      });
 
-
-  const deleteTeam = async (teamId: string) => {
-    if (!window.confirm('Team wirklich löschen?')) return;
-    try {
-      await supabase.from('team_members').delete().eq('team_id', teamId);
-      const { error } = await supabase.from('teams').delete().eq('id', teamId);
-      if (error) throw error;
-      setTeams((prev: any[]) => prev.filter((t: any) => t.id !== teamId));
-      setMessage('✅ Team erfolgreich gelöscht!');
+      setMessage('✅ Benutzer erfolgreich gelöscht!');
       setTimeout(() => setMessage(''), 3000);
-    } catch (err) {
-      console.error('Fehler beim Löschen:', err);
-      setMessage('❌ Fehler beim Löschen des Teams');
+    } catch (error) {
+      console.error('Benutzerlöschen fehlgeschlagen:', error);
+      const message = error instanceof Error ? error.message : 'Fehler beim Löschen des Benutzers';
+      setMessage(`❌ ${message}`);
+      setTimeout(() => setMessage(''), 4000);
     }
   };
-if (loading) {
+
+  const addDepartment = async () => {
+    if (!newDepartmentName.trim()) return;
+
+    try {
+      const response = await fetch('/api/admin/departments', {
+        method: 'POST',
+        headers: postJson,
+        body: JSON.stringify({ name: newDepartmentName.trim() }),
+      });
+
+      if (!response.ok) {
+        const { error } = await response.json();
+        throw new Error(error ?? 'Fehler beim Anlegen der Abteilung');
+      }
+
+      const { data } = await response.json();
+
+      if (data) {
+        setDepartments(prev => [...prev, data]);
+      }
+
+      setNewDepartmentName('');
+      setDepartmentDialogOpen(false);
+      setMessage('✅ Abteilung erfolgreich angelegt!');
+      setTimeout(() => setMessage(''), 3000);
+    } catch (error) {
+      console.error('Fehler beim Anlegen der Abteilung:', error);
+      const message = error instanceof Error ? error.message : 'Fehler beim Anlegen der Abteilung';
+      setMessage(`❌ ${message}`);
+      setTimeout(() => setMessage(''), 4000);
+    }
+  };
+
+  const deleteDepartment = async (departmentId: string) => {
+    if (!window.confirm('Abteilung wirklich löschen?')) return;
+
+    try {
+      const response = await fetch(`/api/admin/departments/${departmentId}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        const { error } = await response.json();
+        throw new Error(error ?? 'Fehler beim Löschen der Abteilung');
+      }
+
+      setDepartments(prev => prev.filter(department => department.id !== departmentId));
+      setMessage('✅ Abteilung erfolgreich gelöscht!');
+      setTimeout(() => setMessage(''), 3000);
+    } catch (error) {
+      console.error('Fehler beim Löschen der Abteilung:', error);
+      const message = error instanceof Error ? error.message : 'Fehler beim Löschen der Abteilung';
+      setMessage(`❌ ${message}`);
+      setTimeout(() => setMessage(''), 4000);
+    }
+  };
+
+  const createUser = async () => {
+    if (!newUserEmail.trim() || !newUserPassword.trim()) return;
+
+    try {
+      const trimmedEmail = newUserEmail.trim();
+      const trimmedPassword = newUserPassword.trim();
+      const trimmedName = newUserName.trim();
+      const trimmedDepartment = newUserDepartment.trim();
+
+      const { data, error } = await supabase.auth.signUp({
+        email: trimmedEmail,
+        password: trimmedPassword,
+        options: {
+          data: {
+            full_name: trimmedName || null,
+            company: trimmedDepartment || null,
+            role: 'user'
+          }
+        }
+      });
+
+      if (error) throw error;
+
+      if (!data.user?.id) {
+        throw new Error('Benutzerkonto konnte nicht erstellt werden.');
+      }
+
+      setCreateUserDialogOpen(false);
+      setNewUserEmail('');
+      setNewUserPassword('');
+      setNewUserName('');
+      setNewUserDepartment('');
+      setMessage('✅ Benutzer erfolgreich erstellt!');
+      await loadData();
+      setTimeout(() => setMessage(''), 3000);
+    } catch (err: any) {
+      console.error('Fehler beim Benutzer anlegen:', err);
+      setMessage(`❌ Fehler beim Erstellen: ${err.message ?? err}`);
+      setTimeout(() => setMessage(''), 4000);
+    }
+  };
+
+  if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
         <Typography variant="h6">🔄 Wird geladen...</Typography>
@@ -226,27 +420,38 @@ if (loading) {
 
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
-      {/* Header */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
-        <Typography variant="h4" component="h1">
-          👥 User & Team Management
-        </Typography>
-        <Button variant="contained" onClick={() => setCreateTeamDialogOpen(true)}>
-          ➕ Neues Team
-        </Button>
-        <Button variant="outlined" onClick={() => setCreateUserDialogOpen(true)} sx={{ ml: 2 }}>
-        👤 Neuer Benutzer
-        </Button>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 2,
+          mb: 4
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Button variant="text" onClick={() => (window.location.href = '/')}>← Zurück</Button>
+          <Typography variant="h4" component="h1">
+            👥 User & Abteilungsverwaltung
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+          <Button variant="outlined" onClick={() => setDepartmentDialogOpen(true)}>
+            🏢 Neue Abteilung
+          </Button>
+          <Button variant="outlined" onClick={() => setCreateUserDialogOpen(true)}>
+            👤 Neuer Benutzer
+          </Button>
+        </Box>
       </Box>
 
-      {/* Message */}
       {message && (
         <Alert severity={message.startsWith('✅') ? 'success' : 'error'} sx={{ mb: 3 }}>
           {message}
         </Alert>
       )}
 
-      {/* Stats Cards */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
         <Grid item xs={12} sm={6} md={3}>
           <Card>
@@ -276,10 +481,10 @@ if (loading) {
           <Card>
             <CardContent sx={{ textAlign: 'center' }}>
               <Typography variant="h3" color="info.main">
-                {teams.length}
+                {departments.length}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                Teams
+                Abteilungen
               </Typography>
             </CardContent>
           </Card>
@@ -298,49 +503,122 @@ if (loading) {
         </Grid>
       </Grid>
 
-      {/* Users Table */}
+      <Card sx={{ mb: 4 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            🏢 Abteilungen
+          </Typography>
+          {departments.length > 0 ? (
+            <Grid container spacing={2}>
+              {departments.map(department => (
+                <Grid item xs={12} sm={6} md={4} key={department.id}>
+                  <Card variant="outlined">
+                    <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2 }}>
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={600}>
+                          {department.name}
+                        </Typography>
+                        {department.created_at && (
+                          <Typography variant="caption" color="text.secondary">
+                            Angelegt: {new Date(department.created_at).toLocaleDateString('de-DE')}
+                          </Typography>
+                        )}
+                      </Box>
+                      <Button
+                        variant="outlined"
+                        color="error"
+                        size="small"
+                        onClick={() => deleteDepartment(department.id)}
+                      >
+                        Löschen
+                      </Button>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+            </Grid>
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              Noch keine Abteilungen angelegt.
+            </Typography>
+          )}
+        </CardContent>
+      </Card>
+
       <Card sx={{ mb: 4 }}>
         <CardContent>
           <Typography variant="h6" gutterBottom>
             👤 Alle Benutzer
           </Typography>
-          <TableContainer>
+          <TableContainer component={Paper}>
             <Table>
               <TableHead>
                 <TableRow>
                   <TableCell>Benutzer</TableCell>
                   <TableCell>E-Mail</TableCell>
+                  <TableCell>Abteilung</TableCell>
                   <TableCell>Rolle</TableCell>
                   <TableCell>Status</TableCell>
                   <TableCell>Registriert</TableCell>
+                  <TableCell align="right">Aktionen</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
-                {users.map((userProfile) => (
-                  <TableRow key={userProfile.id}>
+                {users.map((userProfile) => {
+                  const protectedUser = isProtectedUser(userProfile.id);
+                  return (
+                    <TableRow key={userProfile.id}>
                     <TableCell>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                         <Avatar src={userProfile.avatar_url} sx={{ width: 32, height: 32 }}>
                           {userProfile.full_name?.[0] || userProfile.email[0].toUpperCase()}
                         </Avatar>
-                        <Box>
-                          <Typography variant="body2" fontWeight="bold">
-                            {userProfile.full_name || 'Unbekannt'}
-                          </Typography>
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                          <TextField
+                            value={editableNames[userProfile.id] ?? userProfile.full_name ?? ''}
+                            onChange={(e) => handleInlineNameChange(userProfile.id, e.target.value)}
+                            onBlur={(e) => updateUserName(userProfile.id, e.target.value)}
+                            size="small"
+                            placeholder="Name eingeben"
+                            disabled={protectedUser}
+                          />
                           {userProfile.company && (
                             <Typography variant="caption" color="text.secondary">
                               {userProfile.company}
                             </Typography>
+                          )}
+                          {protectedUser && (
+                            <Chip label="Superuser" size="small" color="secondary" />
                           )}
                         </Box>
                       </Box>
                     </TableCell>
                     <TableCell>{userProfile.email}</TableCell>
                     <TableCell>
+                      <FormControl size="small" sx={{ minWidth: 160 }}>
+                        <Select
+                          displayEmpty
+                          value={userProfile.company || ''}
+                          onChange={(e) => updateUserDepartment(userProfile.id, e.target.value)}
+                          disabled={protectedUser}
+                        >
+                          <MenuItem value="">
+                            <em>Keine</em>
+                          </MenuItem>
+                          {departments.map((department) => (
+                            <MenuItem key={department.id} value={department.name}>
+                              {department.name}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </TableCell>
+                    <TableCell>
                       <FormControl size="small" sx={{ minWidth: 120 }}>
                         <Select
                           value={userProfile.role}
                           onChange={(e) => updateUserRole(userProfile.id, e.target.value)}
+                          disabled={protectedUser}
                         >
                           <MenuItem value="user">User</MenuItem>
                           <MenuItem value="admin">Admin</MenuItem>
@@ -349,60 +627,92 @@ if (loading) {
                       </FormControl>
                     </TableCell>
                     <TableCell>
-                      <Chip 
-                        label={userProfile.is_active ? 'Aktiv' : 'Inaktiv'} 
-                        color={userProfile.is_active ? 'success' : 'default'}
-                        size="small"
-                      />
+                      <Stack direction="row" spacing={1} alignItems="center">
+                        <Switch
+                          checked={userProfile.is_active}
+                          onChange={() => toggleUserActive(userProfile.id, userProfile.is_active)}
+                          inputProps={{ 'aria-label': 'Benutzerstatus umschalten' }}
+                          size="small"
+                          disabled={protectedUser}
+                        />
+                        <Chip
+                          label={userProfile.is_active ? 'Aktiv' : 'Inaktiv'}
+                          color={userProfile.is_active ? 'success' : 'default'}
+                          size="small"
+                        />
+                      </Stack>
                     </TableCell>
                     <TableCell>
                       {new Date(userProfile.created_at).toLocaleDateString('de-DE')}
                     </TableCell>
-                  </TableRow>
-                ))}
+                    <TableCell align="right">
+                      <Tooltip title="Benutzer löschen">
+                        <span>
+                          <IconButton
+                            color="error"
+                            onClick={() => deleteUser(userProfile.id)}
+                            size="small"
+                            disabled={protectedUser}
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </span>
+                      </Tooltip>
+                    </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </TableContainer>
         </CardContent>
       </Card>
 
-      {/* Teams Grid */}
-      <Typography variant="h6" gutterBottom>
-        👥 Teams
-      </Typography>
-      <Grid container spacing={3}>
-        {teams.map((team) => (
-          <Grid item xs={12} sm={6} md={4} key={team.id}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  {team.name}
-                </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                  {team.description || 'Keine Beschreibung'}
-                </Typography>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <Chip label={`${team.member_count} Mitglieder`} size="small" />
-                  <Typography variant="caption" color="text.secondary">
-                    {new Date(team.created_at).toLocaleDateString('de-DE')}
-                  </Typography>
-                
-        <Button variant="outlined" color="error" onClick={() => deleteTeam(team.id)}>Team löschen</Button>
-      </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
-      </Grid>
-
- {/* Create User Dialog */}
       <Dialog open={createUserDialogOpen} onClose={() => setCreateUserDialogOpen(false)} maxWidth="xs" fullWidth>
         <DialogTitle>👤 Neuen Benutzer anlegen</DialogTitle>
         <DialogContent>
-          <TextField label="E-Mail" type="email" value={newUserEmail}
-            onChange={(e) => setNewUserEmail(e.target.value)} fullWidth margin="normal" required />
-          <TextField label="Passwort" type="password" value={newUserPassword}
-            onChange={(e) => setNewUserPassword(e.target.value)} fullWidth margin="normal" required />
+          <TextField
+            label="Name"
+            value={newUserName}
+            onChange={(e) => setNewUserName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+          <TextField
+            label="E-Mail"
+            type="email"
+            value={newUserEmail}
+            onChange={(e) => setNewUserEmail(e.target.value)}
+            fullWidth
+            margin="normal"
+            required
+          />
+          <TextField
+            label="Passwort"
+            type="password"
+            value={newUserPassword}
+            onChange={(e) => setNewUserPassword(e.target.value)}
+            fullWidth
+            margin="normal"
+            required
+          />
+          <FormControl fullWidth margin="normal" size="small">
+            <InputLabel>Abteilung</InputLabel>
+            <Select
+              label="Abteilung"
+              value={newUserDepartment}
+              onChange={(e) => setNewUserDepartment(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>Keine</em>
+              </MenuItem>
+              {departments.map((department) => (
+                <MenuItem key={department.id} value={department.name}>
+                  {department.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setCreateUserDialogOpen(false)}>Abbrechen</Button>
@@ -410,29 +720,29 @@ if (loading) {
         </DialogActions>
       </Dialog>
 
-
-      {/* Create Team Dialog */}
-      <Dialog open={createTeamDialogOpen} onClose={() => setCreateTeamDialogOpen(false)} maxWidth="sm" fullWidth>
-        <DialogTitle>👥 Neues Team erstellen</DialogTitle>
+      <Dialog open={departmentDialogOpen} onClose={() => setDepartmentDialogOpen(false)} maxWidth="xs" fullWidth>
+        <DialogTitle>🏢 Neue Abteilung anlegen</DialogTitle>
         <DialogContent>
           <TextField
-            autoFocus margin="dense" label="Team Name" fullWidth variant="outlined"
-            value={newTeamName} onChange={(e) => setNewTeamName(e.target.value)} sx={{ mb: 2 }}
-          />
-          <TextField
-            margin="dense" label="Beschreibung (optional)" fullWidth multiline rows={3} variant="outlined"
-            value={newTeamDescription} onChange={(e) => setNewTeamDescription(e.target.value)}
+            autoFocus
+            label="Abteilungsname"
+            value={newDepartmentName}
+            onChange={(e) => setNewDepartmentName(e.target.value)}
+            fullWidth
+            margin="normal"
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setCreateTeamDialogOpen(false)}>Abbrechen</Button>
-          <Button onClick={createTeam} variant="contained" disabled={!newTeamName.trim()}>
-            ✅ Erstellen
+          <Button onClick={() => setDepartmentDialogOpen(false)}>Abbrechen</Button>
+          <Button
+            variant="contained"
+            onClick={addDepartment}
+            disabled={!newDepartmentName.trim()}
+          >
+            Speichern
           </Button>
         </DialogActions>
       </Dialog>
     </Container>
- 
-);
+  );
 }
-

--- a/src/components/board/BoardManagementPanel.tsx
+++ b/src/components/board/BoardManagementPanel.tsx
@@ -1,0 +1,1587 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  Grid,
+  IconButton,
+  InputLabel,
+  List,
+  ListItem,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AddIcon from '@mui/icons-material/Add';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { isSuperuserEmail } from '@/constants/superuser';
+import { ClientProfile, fetchClientProfiles } from '@/lib/clientProfiles';
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+import SupabaseConfigNotice from '@/components/SupabaseConfigNotice';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface Department {
+  id: string;
+  name: string;
+}
+
+interface Member {
+  id: string;
+  profile_id: string;
+}
+
+interface AttendanceRecord {
+  id: string;
+  board_id: string;
+  profile_id: string;
+  week_start: string;
+  status: 'present' | 'absent' | string;
+}
+
+interface Topic {
+  id: string;
+  board_id: string;
+  title: string;
+  position: number;
+}
+
+interface KanbanCardRow {
+  id: string;
+  card_id: string;
+  card_data: Record<string, unknown>;
+  project_number?: string | null;
+  project_name?: string | null;
+}
+
+interface EscalationRecord {
+  id?: string;
+  board_id: string;
+  card_id: string;
+  category: 'LK' | 'SK';
+  project_code: string | null;
+  project_name: string | null;
+  reason: string | null;
+  measure: string | null;
+  department_id: string | null;
+  responsible_id: string | null;
+  target_date: string | null;
+  completion_steps: number;
+}
+
+interface EscalationView extends EscalationRecord {
+  title: string;
+  stage?: string | null;
+}
+
+interface EscalationDraft {
+  reason: string;
+  measure: string;
+  department_id: string | null;
+  responsible_id: string | null;
+  target_date: string | null;
+  completion_steps: number;
+}
+
+interface EscalationHistoryEntry {
+  id: string;
+  board_id: string;
+  card_id: string;
+  escalation_id: string | null;
+  changed_at: string;
+  changed_by: string | null;
+  changes?: Record<string, unknown> | null;
+}
+
+interface BoardManagementPanelProps {
+  boardId: string;
+  canEdit: boolean;
+  memberCanSee: boolean;
+}
+
+const ESCALATION_SCHEMA_DOC_PATH = 'docs/patch-board-escalations-card-id.sql';
+const ESCALATION_SCHEMA_HELP =
+  `Bitte führe das SQL-Skript ${ESCALATION_SCHEMA_DOC_PATH} aus, um die fehlende Spalte "card_id" in "board_escalations" anzulegen.`;
+const ESCALATION_HISTORY_DOC_PATH = 'docs/board-escalation-history.sql';
+const ESCALATION_HISTORY_HELP =
+  `Bitte führe das SQL-Skript ${ESCALATION_HISTORY_DOC_PATH} aus, um die Historientabelle für Eskalationen anzulegen.`;
+
+const isMissingEscalationColumnError = (message: string) => {
+  const normalized = message.toLowerCase();
+  return normalized.includes('board_escalations') && normalized.includes('card_id');
+};
+
+const DEFAULT_STAGE_NAMES = [
+  'Werkzeug beim Werkzeugmacher',
+  'Werkzeugtransport',
+  'Werkzeug in Dillenburg',
+  'Werkzeug in Polen',
+  'Musterung',
+  'Teileversand',
+  'Teile vor Ort',
+  'Fertig',
+];
+
+function startOfWeek(date: Date): Date {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function isoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function normalizeWeekValue(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(`${value}T00:00:00`);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return isoDate(startOfWeek(parsed));
+}
+
+function expandWeekRange(values: (string | null | undefined)[], ensureWeek?: string): string[] {
+  const normalized = values
+    .map(normalizeWeekValue)
+    .filter((value): value is string => Boolean(value));
+
+  const ensured = normalizeWeekValue(ensureWeek);
+
+  if (ensured) {
+    normalized.push(ensured);
+  }
+
+  if (normalized.length === 0) {
+    const current = isoDate(startOfWeek(new Date()));
+    return [current];
+  }
+
+  const uniqueSorted = Array.from(new Set(normalized)).sort(
+    (a, b) => new Date(`${a}T00:00:00`).getTime() - new Date(`${b}T00:00:00`).getTime(),
+  );
+
+  const firstDate = startOfWeek(new Date(`${uniqueSorted[0]}T00:00:00`));
+  const currentWeek = startOfWeek(new Date());
+  const ensuredDate = ensured ? startOfWeek(new Date(`${ensured}T00:00:00`)) : null;
+  const lastCandidate = startOfWeek(
+    new Date(`${uniqueSorted[uniqueSorted.length - 1]}T00:00:00`),
+  );
+
+  const lastDate = new Date(
+    Math.max(
+      lastCandidate.getTime(),
+      currentWeek.getTime(),
+      ensuredDate?.getTime() ?? -Infinity,
+    ),
+  );
+
+  const result: string[] = [];
+  for (let cursor = new Date(firstDate); cursor.getTime() <= lastDate.getTime(); ) {
+    result.push(isoDate(cursor));
+    cursor.setDate(cursor.getDate() + 7);
+    cursor.setHours(0, 0, 0, 0);
+  }
+
+  return result;
+}
+
+function weekRangeLabel(weekStart: Date): string {
+  const end = new Date(weekStart);
+  end.setDate(end.getDate() + 4);
+  const startFmt = weekStart.toLocaleDateString('de-DE');
+  const endFmt = end.toLocaleDateString('de-DE');
+  return `${startFmt} – ${endFmt}`;
+}
+
+function isoWeekNumber(date: Date): number {
+  const target = new Date(date.valueOf());
+  const dayNr = (target.getDay() + 6) % 7;
+  target.setDate(target.getDate() - dayNr + 3);
+  const firstThursday = target.valueOf();
+  target.setMonth(0, 1);
+  const dayOfWeek = (target.getDay() + 6) % 7;
+  target.setDate(target.getDate() - dayOfWeek + 3);
+  const weekNumber = 1 + Math.round((firstThursday - target.valueOf()) / 604800000);
+  return weekNumber;
+}
+
+function isoWeekYear(date: Date): number {
+  const target = new Date(date.valueOf());
+  target.setDate(target.getDate() - ((target.getDay() + 6) % 7) + 3);
+  return target.getFullYear();
+}
+
+function dateFromIsoWeek(year: number, week: number): Date {
+  const simple = new Date(year, 0, 4);
+  const simpleDay = simple.getDay() || 7;
+  simple.setDate(simple.getDate() - simpleDay + 1 + (week - 1) * 7);
+  simple.setHours(0, 0, 0, 0);
+  return simple;
+}
+
+function formatWeekInputValue(date: Date): string {
+  const week = isoWeekNumber(date).toString().padStart(2, '0');
+  const year = isoWeekYear(date);
+  return `${year}-W${week}`;
+}
+
+function parseWeekInputValue(value: string): string | null {
+  const trimmed = value.trim();
+  const match = /^([0-9]{4})-W([0-9]{2})$/i.exec(trimmed);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, yearText, weekText] = match;
+  const year = Number(yearText);
+  const week = Number(weekText);
+
+  if (!Number.isFinite(year) || !Number.isFinite(week) || week < 1 || week > 53) {
+    return null;
+  }
+
+  const weekDate = startOfWeek(dateFromIsoWeek(year, week));
+  return isoDate(weekDate);
+}
+
+function CompletionDial({
+  steps,
+  onClick,
+  disabled,
+}: {
+  steps: number;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  const clamped = Math.max(0, Math.min(4, steps || 0));
+  const angle = (clamped / 4) * 360;
+  const background = `conic-gradient(#4caf50 0deg ${angle}deg, #e0e0e0 ${angle}deg 360deg)`;
+  return (
+    <Box
+      onClick={disabled ? undefined : onClick}
+      sx={{
+        width: 40,
+        height: 40,
+        borderRadius: '50%',
+        border: '1px solid',
+        borderColor: 'divider',
+        backgroundImage: background,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        transition: 'transform 0.2s ease',
+        '&:hover': disabled
+          ? undefined
+          : {
+              transform: 'scale(1.05)',
+            },
+      }}
+    />
+  );
+}
+
+function mergeMemberProfiles(members: Member[], profiles: ClientProfile[]): (Member & { profile?: ClientProfile })[] {
+  const profileMap = new Map(profiles.map(profile => [profile.id, profile]));
+  return members.map(member => ({
+    ...member,
+    profile: profileMap.get(member.profile_id),
+  }));
+}
+
+const stringOrNull = (value: unknown): string | null => {
+  if (value === null || value === undefined) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+};
+
+function extractStageOrder(settings: unknown): string[] {
+  if (!settings || typeof settings !== 'object') {
+    return [];
+  }
+
+  const maybeCols = (settings as { cols?: Array<{ name?: string }> }).cols;
+
+  if (!Array.isArray(maybeCols)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      maybeCols
+        .map(col => (col && typeof col === 'object' ? stringOrNull((col as any).name) : null))
+        .filter((name): name is string => Boolean(name)),
+    ),
+  );
+}
+
+function buildEscalationViews(
+  boardId: string,
+  cards: KanbanCardRow[],
+  records: EscalationRecord[],
+): EscalationView[] {
+  const recordByCard = new Map(records.filter(record => record.card_id).map(record => [record.card_id, record]));
+
+  return cards
+    .map(card => {
+      const rawData = (card.card_data ?? {}) as Record<string, unknown>;
+      const rawCategory = stringOrNull(rawData['Eskalation']);
+      const category = rawCategory?.toUpperCase();
+
+      if (category !== 'LK' && category !== 'SK') {
+        return null;
+      }
+
+      const record = recordByCard.get(card.card_id);
+
+      const projectCode = stringOrNull(rawData['Nummer']) ?? stringOrNull(card.project_number);
+      const projectName = stringOrNull(rawData['Teil']) ?? stringOrNull(card.project_name);
+      const stage = stringOrNull(rawData['Board Stage']);
+      const fallbackReason = stringOrNull(rawData['Grund']);
+      const fallbackMeasure = stringOrNull(rawData['Maßnahme']) ?? stringOrNull(rawData['Massnahme']);
+      const completion = Math.max(0, Math.min(4, record?.completion_steps ?? 0));
+
+      const view: EscalationView = {
+        id: record?.id,
+        board_id: record?.board_id ?? boardId,
+        card_id: card.card_id,
+        category: (category as 'LK' | 'SK'),
+        project_code: record?.project_code ?? projectCode,
+        project_name: record?.project_name ?? projectName,
+        reason: record?.reason ?? fallbackReason ?? null,
+        measure: record?.measure ?? fallbackMeasure ?? null,
+        department_id: record?.department_id ?? null,
+        responsible_id: record?.responsible_id ?? null,
+        target_date: record?.target_date ?? null,
+        completion_steps: completion,
+        title: [projectCode, projectName].filter(Boolean).join(' • ') || card.card_id,
+        stage,
+      };
+
+      return view;
+    })
+    .filter((entry): entry is EscalationView => entry !== null);
+}
+
+export default function BoardManagementPanel({ boardId, canEdit, memberCanSee }: BoardManagementPanelProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+
+  if (!supabase) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <SupabaseConfigNotice />
+      </Box>
+    );
+  }
+
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  const [profiles, setProfiles] = useState<ClientProfile[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [members, setMembers] = useState<(Member & { profile?: ClientProfile })[]>([]);
+  const [memberSelect, setMemberSelect] = useState('');
+
+  const [selectedWeek, setSelectedWeek] = useState<string>(() => isoDate(startOfWeek(new Date())));
+  const [orderedWeeks, setOrderedWeeks] = useState<string[]>(() =>
+    expandWeekRange([isoDate(startOfWeek(new Date()))]),
+  );
+  const [attendanceByWeek, setAttendanceByWeek] = useState<
+    Record<string, Record<string, AttendanceRecord | undefined>>
+  >({});
+  const [attendanceDraft, setAttendanceDraft] = useState<Record<string, boolean>>({});
+  const [attendanceSaving, setAttendanceSaving] = useState(false);
+  const [escalationHistory, setEscalationHistory] = useState<Record<string, EscalationHistoryEntry[]>>({});
+  const [escalationHistoryReady, setEscalationHistoryReady] = useState(true);
+  const [currentProfileId, setCurrentProfileId] = useState<string | null>(null);
+
+  const [topics, setTopics] = useState<Topic[]>([]);
+  const [escalations, setEscalations] = useState<EscalationView[]>([]);
+  const [escalationSchemaReady, setEscalationSchemaReady] = useState(true);
+  const [escalationDialogOpen, setEscalationDialogOpen] = useState(false);
+  const [editingEscalation, setEditingEscalation] = useState<EscalationView | null>(null);
+  const [escalationDraft, setEscalationDraft] = useState<EscalationDraft | null>(null);
+  const [stageChartData, setStageChartData] = useState<{ stage: string; count: number }[]>([]);
+
+  const selectedWeekDate = useMemo(() => {
+    if (!selectedWeek) {
+      return startOfWeek(new Date());
+    }
+
+    const parsed = new Date(`${selectedWeek}T00:00:00`);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return startOfWeek(new Date());
+    }
+
+    return startOfWeek(parsed);
+  }, [selectedWeek]);
+
+  const selectedWeekInputValue = useMemo(
+    () => formatWeekInputValue(selectedWeekDate),
+    [selectedWeekDate],
+  );
+
+  const sortedWeekEntries = useMemo(() => {
+    const baseWeeks = orderedWeeks.length ? orderedWeeks : [selectedWeek];
+    const entries = baseWeeks.map(week => ({
+      week,
+      date: startOfWeek(new Date(`${week}T00:00:00`)),
+    }));
+
+    if (!entries.some(entry => entry.week === selectedWeek)) {
+      entries.push({ week: selectedWeek, date: selectedWeekDate });
+    }
+
+    return entries.sort((a, b) => b.date.getTime() - a.date.getTime());
+  }, [orderedWeeks, selectedWeek, selectedWeekDate]);
+
+  const historyWeeks = useMemo(
+    () => sortedWeekEntries.filter(entry => entry.week !== selectedWeek),
+    [sortedWeekEntries, selectedWeek],
+  );
+
+  const availableProfiles = useMemo(() => {
+    const memberIds = new Set(members.map(member => member.profile_id));
+    return profiles.filter(profile => {
+      if (isSuperuserEmail(profile.email)) {
+        return false;
+      }
+
+      const isActive = profile.is_active ?? true;
+      return isActive && !memberIds.has(profile.id);
+    });
+  }, [members, profiles]);
+
+  const filteredEscalations = useMemo(() => ({
+    LK: escalations.filter(entry => entry.category === 'LK'),
+    SK: escalations.filter(entry => entry.category === 'SK'),
+  }), [escalations]);
+
+  const profileById = useMemo(() => {
+    const map = new Map<string, ClientProfile>();
+    profiles.forEach(profile => {
+      map.set(profile.id, profile);
+    });
+    return map;
+  }, [profiles]);
+
+  const toggleAttendanceDraft = (profileId: string) => {
+    setAttendanceDraft(prev => ({ ...prev, [profileId]: !(prev[profileId] ?? true) }));
+  };
+
+  const selectWeek = (week: string) => {
+    if (!week) return;
+
+    const parsed = new Date(`${week}T00:00:00`);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return;
+    }
+
+    const normalized = isoDate(startOfWeek(parsed));
+    setSelectedWeek(normalized);
+    setOrderedWeeks(prev => expandWeekRange([...prev, normalized], normalized));
+  };
+
+  const handleWeekInputChange = (value: string) => {
+    const parsed = parseWeekInputValue(value);
+
+    if (parsed) {
+      setSelectedWeek(parsed);
+      setOrderedWeeks(prev => expandWeekRange([...prev, parsed], parsed));
+    }
+  };
+
+  useEffect(() => {
+    const records = attendanceByWeek[selectedWeek] ?? {};
+    const draft: Record<string, boolean> = {};
+    members.forEach(member => {
+      const record = records[member.profile_id];
+      draft[member.profile_id] = record?.status !== 'absent';
+    });
+    setAttendanceDraft(draft);
+  }, [attendanceByWeek, members, selectedWeek]);
+
+  const handleError = (error: unknown, fallback: string) => {
+    console.error(fallback, error);
+    const message = error instanceof Error ? error.message : String(error);
+    if (isMissingEscalationColumnError(message)) {
+      setEscalationSchemaReady(false);
+      setMessage(`❌ ${fallback}: ${ESCALATION_SCHEMA_HELP}`);
+      setTimeout(() => setMessage(''), 10000);
+      return;
+    }
+
+    setMessage(`❌ ${fallback}: ${message}`);
+    setTimeout(() => setMessage(''), 4000);
+  };
+
+  const loadBaseData = async (options?: { skipLoading?: boolean }): Promise<boolean> => {
+    const skipLoading = options?.skipLoading ?? false;
+    try {
+      if (!skipLoading) {
+        setLoading(true);
+      }
+      const profilePromise = fetchClientProfiles();
+
+      const [
+        departmentsResult,
+        membersResult,
+        topicsResult,
+        escalationsResult,
+        cardsResult,
+        settingsResult,
+        historyResult,
+      ] = await Promise.all([
+        supabase.from('departments').select('*').order('name'),
+        supabase.from('board_members').select('*').eq('board_id', boardId).order('created_at'),
+        supabase.from('board_top_topics').select('*').eq('board_id', boardId).order('position'),
+        supabase.from('board_escalations').select('*').eq('board_id', boardId),
+        supabase
+          .from('kanban_cards')
+          .select('id, card_id, card_data, project_number, project_name')
+          .eq('board_id', boardId),
+        supabase
+          .from('kanban_board_settings')
+          .select('settings')
+          .eq('board_id', boardId)
+          .maybeSingle(),
+        supabase
+          .from('board_escalation_history')
+          .select('*')
+          .eq('board_id', boardId)
+          .order('changed_at', { ascending: false }),
+      ]);
+
+      const profileRows = (await profilePromise).filter(
+        profile => !isSuperuserEmail(profile.email),
+      );
+
+      if (departmentsResult.error) throw new Error(departmentsResult.error.message);
+      if (membersResult.error) throw new Error(membersResult.error.message);
+      if (topicsResult.error) throw new Error(topicsResult.error.message);
+      let escalationSchemaMissing = false;
+      if (escalationsResult.error) {
+        const message = escalationsResult.error.message;
+        if (message && isMissingEscalationColumnError(message)) {
+          escalationSchemaMissing = true;
+        } else {
+          throw new Error(message ?? 'Unbekannter Fehler beim Laden der Eskalationen');
+        }
+      }
+      if (cardsResult.error) throw new Error(cardsResult.error.message);
+      if (settingsResult.error && settingsResult.error.code !== 'PGRST116') {
+        throw new Error(settingsResult.error.message);
+      }
+      let historyRows: EscalationHistoryEntry[] = [];
+      if (historyResult.error) {
+        const message = historyResult.error.message ?? '';
+        if (message.toLowerCase().includes('board_escalation_history')) {
+          setEscalationHistoryReady(false);
+          setMessage(`⚠️ ${ESCALATION_HISTORY_HELP}`);
+          setTimeout(() => setMessage(''), 10000);
+        } else {
+          throw new Error(historyResult.error.message);
+        }
+      } else {
+        setEscalationHistoryReady(true);
+        historyRows = (historyResult.data as EscalationHistoryEntry[] | null) ?? [];
+      }
+
+      const departmentRows = (departmentsResult.data as Department[]) ?? [];
+      const memberRows = mergeMemberProfiles((membersResult.data as Member[]) ?? [], profileRows);
+      const topicRows = (topicsResult.data as Topic[]) ?? [];
+      const escalationRecords = escalationSchemaMissing
+        ? []
+        : ((escalationsResult.data as EscalationRecord[]) ?? []);
+      const cardRows = (cardsResult.data as KanbanCardRow[]) ?? [];
+      const escalationViews = buildEscalationViews(boardId, cardRows, escalationRecords);
+      const settingsRow = (settingsResult.data as { settings?: unknown } | null) ?? null;
+      const stageOrder = extractStageOrder(settingsRow?.settings);
+      const baseStages = stageOrder.length ? stageOrder : DEFAULT_STAGE_NAMES;
+      const stageCounts = cardRows.reduce((map, row) => {
+        const raw = (row.card_data ?? {}) as Record<string, unknown>;
+        const stage =
+          stringOrNull(raw['Board Stage']) ??
+          stringOrNull(raw['stage'] as string | undefined) ??
+          'Unbekannt';
+        map.set(stage, (map.get(stage) ?? 0) + 1);
+        return map;
+      }, new Map<string, number>());
+      baseStages.forEach(stage => {
+        if (!stageCounts.has(stage)) {
+          stageCounts.set(stage, 0);
+        }
+      });
+      const additionalStages = Array.from(stageCounts.keys()).filter(
+        stage => !baseStages.includes(stage),
+      );
+      const stageList = [
+        ...baseStages,
+        ...additionalStages.sort((a, b) =>
+          a.localeCompare(b, 'de', { numeric: true, sensitivity: 'base' }),
+        ),
+      ];
+      const chartData = stageList.map(stage => ({ stage, count: stageCounts.get(stage) ?? 0 }));
+
+      setProfiles(profileRows);
+      setDepartments(departmentRows);
+      setMembers(memberRows);
+      setTopics(topicRows);
+      setEscalations(escalationViews);
+      setEscalationSchemaReady(!escalationSchemaMissing);
+      if (escalationSchemaMissing) {
+        setMessage(`⚠️ ${ESCALATION_SCHEMA_HELP}`);
+        setTimeout(() => setMessage(''), 10000);
+      }
+      const historyMap: Record<string, EscalationHistoryEntry[]> = {};
+      historyRows.forEach(entry => {
+        const list = historyMap[entry.card_id] ?? [];
+        historyMap[entry.card_id] = [...list, entry];
+      });
+      setEscalationHistory(historyMap);
+      setStageChartData(chartData);
+      return true;
+    } catch (error) {
+      handleError(error, 'Fehler beim Laden der Board-Daten');
+      return false;
+    } finally {
+      if (!skipLoading) {
+        setLoading(false);
+      }
+    }
+  };
+
+  const loadAttendanceHistory = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('board_attendance')
+        .select('*')
+        .eq('board_id', boardId)
+        .order('week_start', { ascending: false });
+
+      if (error) throw new Error(error.message);
+
+      const map: Record<string, Record<string, AttendanceRecord | undefined>> = {};
+      (data as AttendanceRecord[] | null)?.forEach(entry => {
+        const key = entry.week_start;
+        if (!map[key]) {
+          map[key] = {};
+        }
+        map[key][entry.profile_id] = entry;
+      });
+
+      setAttendanceByWeek(map);
+      const ordered = expandWeekRange(Object.keys(map), selectedWeek);
+      setOrderedWeeks(ordered);
+
+      if (!ordered.includes(selectedWeek) && ordered.length > 0) {
+        setSelectedWeek(ordered[ordered.length - 1]);
+      }
+    } catch (error) {
+      handleError(error, 'Fehler beim Laden der Anwesenheit');
+    }
+  };
+
+  useEffect(() => {
+    loadBaseData();
+  }, [boardId]);
+
+  useEffect(() => {
+    loadAttendanceHistory();
+  }, [boardId]);
+
+  const adjustWeek = (offset: number) => {
+    if (!offset) return;
+
+    const next = new Date(selectedWeekDate);
+    next.setDate(next.getDate() + offset * 7);
+    const normalized = isoDate(startOfWeek(next));
+    setSelectedWeek(normalized);
+    setOrderedWeeks(prev => expandWeekRange([...prev, normalized], normalized));
+  };
+
+  const saveAttendance = async () => {
+    if (!canEdit || members.length === 0) {
+      return;
+    }
+
+    try {
+      setAttendanceSaving(true);
+      const payload = members.map(member => ({
+        board_id: boardId,
+        profile_id: member.profile_id,
+        week_start: selectedWeek,
+        status: (attendanceDraft[member.profile_id] ?? true) ? 'present' : 'absent',
+      }));
+
+      const { error } = await supabase
+        .from('board_attendance')
+        .upsert(payload, { onConflict: 'board_id,profile_id,week_start' });
+
+      if (error) throw new Error(error.message);
+
+      await loadAttendanceHistory();
+      setMessage('✅ Anwesenheit gespeichert');
+      setTimeout(() => setMessage(''), 4000);
+    } catch (error) {
+      handleError(error, 'Fehler beim Speichern der Anwesenheit');
+    } finally {
+      setAttendanceSaving(false);
+    }
+  };
+
+  const addMember = async () => {
+    if (!memberSelect) return;
+    try {
+      const { data, error } = await supabase
+        .from('board_members')
+        .insert({ board_id: boardId, profile_id: memberSelect })
+        .select()
+        .single();
+
+      if (error) throw new Error(error.message);
+
+      const profile = profiles.find(entry => entry.id === memberSelect);
+      setMembers(prev => [...prev, { ...(data as Member), profile }]);
+      setMemberSelect('');
+    } catch (error) {
+      handleError(error, 'Fehler beim Hinzufügen des Mitglieds');
+    }
+  };
+
+  const removeMember = async (memberId: string) => {
+    try {
+      const { error } = await supabase
+        .from('board_members')
+        .delete()
+        .eq('id', memberId);
+
+      if (error) throw new Error(error.message);
+
+      setMembers(prev => prev.filter(member => member.id !== memberId));
+    } catch (error) {
+      handleError(error, 'Fehler beim Entfernen des Mitglieds');
+    }
+  };
+
+  const addTopic = async () => {
+    if (topics.length >= 5) return;
+    try {
+      const { data, error } = await supabase
+        .from('board_top_topics')
+        .insert({
+          board_id: boardId,
+          title: '',
+          position: topics.length,
+        })
+        .select()
+        .single();
+
+      if (error) throw new Error(error.message);
+
+      if (data) {
+        setTopics(prev => [...prev, data as Topic]);
+      }
+    } catch (error) {
+      handleError(error, 'Fehler beim Hinzufügen eines Top-Themas');
+    }
+  };
+
+  const updateTopic = async (topicId: string, title: string) => {
+    try {
+      const { error } = await supabase
+        .from('board_top_topics')
+        .update({ title })
+        .eq('id', topicId);
+
+      if (error) throw new Error(error.message);
+
+      setTopics(prev => prev.map(topic => (topic.id === topicId ? { ...topic, title } : topic)));
+    } catch (error) {
+      handleError(error, 'Fehler beim Aktualisieren des Top-Themas');
+    }
+  };
+
+  const deleteTopic = async (topicId: string) => {
+    try {
+      const { error } = await supabase
+        .from('board_top_topics')
+        .delete()
+        .eq('id', topicId);
+
+      if (error) throw new Error(error.message);
+
+      setTopics(prev => prev.filter(topic => topic.id !== topicId));
+    } catch (error) {
+      handleError(error, 'Fehler beim Löschen des Top-Themas');
+    }
+  };
+
+
+  const departmentName = (departmentId: string | null) =>
+    departments.find(entry => entry.id === departmentId)?.name ?? '';
+
+  const departmentIdByName = (name: string) =>
+    departments.find(entry => entry.name === name)?.id ?? null;
+
+  const responsibleOptions = (departmentId: string | null) => {
+    const name = departmentName(departmentId);
+    return profiles.filter(profile => {
+      if (isSuperuserEmail(profile.email)) {
+        return false;
+      }
+
+      const matchesDepartment = name ? profile.company === name : true;
+      const isActive = profile.is_active ?? true;
+      return matchesDepartment && isActive;
+    });
+  };
+
+  const canEditEscalations = memberCanSee;
+
+  useEffect(() => {
+    supabase.auth
+      .getUser()
+      .then(result => {
+        setCurrentProfileId(result.data.user?.id ?? null);
+      })
+      .catch(() => {
+        setCurrentProfileId(null);
+      });
+  }, [supabase]);
+
+  const openEscalationEditor = (entry: EscalationView) => {
+    setEditingEscalation(entry);
+    setEscalationDraft({
+      reason: entry.reason ?? '',
+      measure: entry.measure ?? '',
+      department_id: entry.department_id ?? null,
+      responsible_id: entry.responsible_id ?? null,
+      target_date: entry.target_date ?? null,
+      completion_steps: entry.completion_steps ?? 0,
+    });
+    setEscalationDialogOpen(true);
+  };
+
+  const closeEscalationEditor = () => {
+    setEscalationDialogOpen(false);
+    setEditingEscalation(null);
+    setEscalationDraft(null);
+  };
+
+  const updateEscalationDraft = (changes: Partial<EscalationDraft>) => {
+    setEscalationDraft(prev => (prev ? { ...prev, ...changes } : prev));
+  };
+
+  const saveEscalation = async () => {
+    if (!canEditEscalations) {
+      setMessage('❌ Keine Berechtigung zum Bearbeiten von Eskalationen.');
+      setTimeout(() => setMessage(''), 4000);
+      return;
+    }
+    if (!editingEscalation || !escalationDraft) return;
+    if (!escalationSchemaReady) {
+      setMessage(`❌ Eskalationen können erst gespeichert werden, nachdem ${ESCALATION_SCHEMA_HELP}`);
+      setTimeout(() => setMessage(''), 10000);
+      return;
+    }
+
+    try {
+      const currentEscalation = editingEscalation;
+      const payload = {
+        board_id: boardId,
+        card_id: currentEscalation.card_id,
+        category: currentEscalation.category,
+        project_code: currentEscalation.project_code,
+        project_name: currentEscalation.project_name,
+        reason: stringOrNull(escalationDraft.reason),
+        measure: stringOrNull(escalationDraft.measure),
+        department_id: escalationDraft.department_id,
+        responsible_id: escalationDraft.responsible_id,
+        target_date: escalationDraft.target_date,
+        completion_steps: Math.max(0, Math.min(4, escalationDraft.completion_steps ?? 0)),
+      };
+
+      const { data, error } = await supabase
+        .from('board_escalations')
+        .upsert(payload, { onConflict: 'board_id,card_id' })
+        .select()
+        .maybeSingle();
+
+      if (error) throw new Error(error.message);
+
+      setEscalations(prev =>
+        prev.map(entry =>
+          entry.card_id === currentEscalation.card_id
+            ? {
+                ...entry,
+                id: (data as EscalationRecord | null)?.id ?? entry.id,
+                reason: payload.reason ?? null,
+                measure: payload.measure ?? null,
+                department_id: payload.department_id ?? null,
+                responsible_id: payload.responsible_id ?? null,
+                target_date: payload.target_date ?? null,
+                completion_steps: payload.completion_steps ?? 0,
+              }
+            : entry,
+        ),
+      );
+      const escalationId = (data as EscalationRecord | null)?.id ?? currentEscalation.id ?? null;
+
+      if (escalationHistoryReady && currentProfileId && escalationId) {
+        const { error: historyError } = await supabase
+          .from('board_escalation_history')
+          .insert({
+            board_id: boardId,
+            card_id: currentEscalation.card_id,
+            escalation_id: escalationId,
+            changed_by: currentProfileId,
+            changes: payload,
+          });
+        if (historyError) {
+          console.error('⚠️ Fehler beim Schreiben der Eskalationshistorie', historyError);
+        }
+      }
+
+      closeEscalationEditor();
+      const refreshed = await loadBaseData({ skipLoading: true });
+
+      if (refreshed) {
+        setMessage('✅ Eskalation gespeichert');
+        setTimeout(() => setMessage(''), 4000);
+      }
+    } catch (error) {
+      handleError(error, 'Fehler beim Speichern der Eskalation');
+    }
+  };
+
+  const cycleDraftCompletion = () => {
+    if (!escalationDraft) return;
+    const current = escalationDraft.completion_steps ?? 0;
+    const next = current >= 4 ? 0 : current + 1;
+    updateEscalationDraft({ completion_steps: next });
+  };
+
+  if (!memberCanSee) {
+    return (
+      <Card>
+        <CardContent>
+          <Typography>Keine Berechtigung zum Anzeigen der Management-Ansicht.</Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 8, textAlign: 'center' }}>
+        <Typography variant="body1">🔄 Management-Daten werden geladen...</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={3} sx={{ pb: 6 }}>
+      {message && <Alert severity={message.startsWith('❌') ? 'error' : 'success'}>{message}</Alert>}
+
+      <Card>
+        <CardContent>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} flexWrap="wrap">
+            <Box>
+              <Typography variant="h6">👥 Board-Mitglieder</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Füge Mitglieder hinzu, um Anwesenheit und Verantwortlichkeiten zu erfassen.
+              </Typography>
+            </Box>
+            {canEdit && (
+              <Stack direction="row" spacing={1} alignItems="center">
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Mitglied hinzufügen</InputLabel>
+                  <Select
+                    label="Mitglied hinzufügen"
+                    value={memberSelect}
+                    onChange={(event) => setMemberSelect(event.target.value)}
+                  >
+                    <MenuItem value="">
+                      <em>Auswählen</em>
+                    </MenuItem>
+                    {availableProfiles.map(profile => (
+                      <MenuItem key={profile.id} value={profile.id}>
+                        {(profile.full_name || profile.email) + (profile.company ? ` • ${profile.company}` : '')}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={addMember}
+                  disabled={!memberSelect}
+                >
+                  Hinzufügen
+                </Button>
+              </Stack>
+            )}
+          </Stack>
+
+          <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mt: 3 }}>
+            {members.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                Noch keine Mitglieder hinterlegt.
+              </Typography>
+            )}
+            {members.map(member => {
+              const label = member.profile?.full_name || member.profile?.email || 'Unbekannt';
+              const detail = member.profile?.company ? ` (${member.profile.company})` : '';
+              const deletable = canEdit && !isSuperuserEmail(member.profile?.email ?? null);
+              return (
+                <Chip
+                  key={member.id}
+                  label={`${label}${detail}`}
+                  onDelete={deletable ? () => removeMember(member.id) : undefined}
+                  sx={{ mr: 1, mb: 1 }}
+                  color={(member.profile?.is_active ?? true) ? 'primary' : 'default'}
+                />
+              );
+            })}
+          </Stack>
+        </CardContent>
+      </Card>
+
+
+      <Card>
+        <CardContent>
+          <Stack spacing={2}>
+            <Stack
+              direction={{ xs: 'column', md: 'row' }}
+              spacing={2}
+              alignItems={{ md: 'center' }}
+              justifyContent="space-between"
+            >
+              <Box>
+                <Typography variant="h6">🗓️ Anwesenheit</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  KW {isoWeekNumber(selectedWeekDate)} · {weekRangeLabel(selectedWeekDate)}
+                </Typography>
+              </Box>
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <IconButton onClick={() => adjustWeek(-1)} aria-label="Vorherige Woche">
+                  <ArrowBackIcon />
+                </IconButton>
+                <TextField
+                  type="week"
+                  label="Kalenderwoche"
+                  size="small"
+                  value={selectedWeekInputValue}
+                  onChange={event => handleWeekInputChange(event.target.value)}
+                  InputLabelProps={{ shrink: true }}
+                  sx={{ minWidth: 180 }}
+                />
+                <IconButton onClick={() => adjustWeek(1)} aria-label="Nächste Woche">
+                  <ArrowForwardIcon />
+                </IconButton>
+                <Button
+                  variant="contained"
+                  onClick={saveAttendance}
+                  disabled={!canEdit || attendanceSaving || members.length === 0}
+                >
+                  Diese Woche speichern
+                </Button>
+              </Stack>
+            </Stack>
+
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ minWidth: 220 }}>Mitglied</TableCell>
+                    <TableCell align="center" sx={{ minWidth: 160 }}>
+                      <Stack spacing={0.5} alignItems="center">
+                        <Typography variant="subtitle2">
+                          KW {isoWeekNumber(selectedWeekDate)}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {weekRangeLabel(selectedWeekDate)}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                    {historyWeeks.map(history => (
+                      <TableCell key={history.week} align="center" sx={{ minWidth: 140 }}>
+                        <Stack spacing={0.5} alignItems="center">
+                          <Button
+                            size="small"
+                            variant={history.week === selectedWeek ? 'contained' : 'text'}
+                            onClick={() => selectWeek(history.week)}
+                          >
+                            KW {isoWeekNumber(history.date)}
+                          </Button>
+                          <Typography variant="caption" color="text.secondary">
+                            {weekRangeLabel(history.date)}
+                          </Typography>
+                        </Stack>
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {members.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={historyWeeks.length + 2}>
+                        <Typography variant="body2" color="text.secondary">
+                          Füge Mitglieder hinzu, um Anwesenheiten zu dokumentieren.
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    members.map(member => {
+                      const profile = member.profile;
+                      const label = profile?.full_name || profile?.email || 'Unbekannt';
+                      const department = profile?.company;
+                      const present = attendanceDraft[member.profile_id] ?? true;
+                      return (
+                        <TableRow key={member.id} hover>
+                          <TableCell>
+                            <Stack spacing={0.25}>
+                              <Typography variant="subtitle2">{label}</Typography>
+                              {department && (
+                                <Typography variant="caption" color="text.secondary">
+                                  {department}
+                                </Typography>
+                              )}
+                            </Stack>
+                          </TableCell>
+                          <TableCell align="center">
+                            <Tooltip title={present ? 'Anwesend' : 'Abwesend'}>
+                              <span>
+                                <Checkbox
+                                  checked={present}
+                                  onChange={() => toggleAttendanceDraft(member.profile_id)}
+                                  disabled={!canEdit || attendanceSaving}
+                                  icon={<CloseIcon color="error" />}
+                                  checkedIcon={<CheckIcon color="success" />}
+                                  sx={{ '& .MuiSvgIcon-root': { fontSize: 28 } }}
+                                />
+                              </span>
+                            </Tooltip>
+                          </TableCell>
+                          {historyWeeks.map(history => {
+                            const record = attendanceByWeek[history.week]?.[member.profile_id];
+                            if (!record) {
+                              return (
+                                <TableCell key={history.week} align="center">
+                                  <Typography variant="caption" color="text.secondary">
+                                    —
+                                  </Typography>
+                                </TableCell>
+                              );
+                            }
+                            const wasPresent = record.status !== 'absent';
+                            return (
+                              <TableCell key={history.week} align="center">
+                                {wasPresent ? (
+                                  <CheckIcon color="success" fontSize="small" />
+                                ) : (
+                                  <CloseIcon color="error" fontSize="small" />
+                                )}
+                              </TableCell>
+                            );
+                          })}
+                        </TableRow>
+                      );
+                    })
+                  )}
+                </TableBody>
+              </Table>
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            📈 Projekte pro Phase
+          </Typography>
+          {stageChartData.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              Es liegen keine Projektdaten mit Phaseninformationen vor.
+            </Typography>
+          ) : (
+            <Box sx={{ width: '100%', height: 260 }}>
+              <ResponsiveContainer>
+                <LineChart data={stageChartData} margin={{ top: 16, right: 24, bottom: 8, left: 8 }}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="stage" angle={-15} textAnchor="end" height={60} interval={0} />
+                  <YAxis allowDecimals={false} />
+                  <RechartsTooltip
+                    formatter={(value: number | string) => [`${value} Projekte`, 'Anzahl']}
+                  />
+                  <Line type="monotone" dataKey="count" stroke="#1976d2" strokeWidth={2} dot />
+                </LineChart>
+              </ResponsiveContainer>
+            </Box>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Stack direction="row" justifyContent="space-between" alignItems="center" spacing={2} flexWrap="wrap">
+            <Box>
+              <Typography variant="h6">🚨 Projekte in Eskalation</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Es werden automatisch alle Karten angezeigt, die im Board als LK oder SK markiert sind.
+              </Typography>
+            </Box>
+          </Stack>
+
+          {!escalationSchemaReady && (
+            <Alert severity="warning" sx={{ mt: 2 }}>
+              {ESCALATION_SCHEMA_HELP}
+            </Alert>
+          )}
+
+          <Divider sx={{ my: 2 }} />
+
+          {(['LK', 'SK'] as const).map(category => {
+            const entries = filteredEscalations[category];
+            return (
+              <Box key={category} sx={{ mb: category === 'LK' ? 3 : 0 }}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                  {category} Eskalationen
+                </Typography>
+
+                {entries.length === 0 ? (
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    {category === 'LK'
+                      ? 'Keine LK Eskalationen vorhanden.'
+                      : 'Keine SK Eskalationen vorhanden.'}
+                  </Typography>
+                ) : (
+                  <Stack spacing={2} sx={{ mb: 2 }}>
+                    {entries.map(entry => {
+                      const responsible = entry.responsible_id ? profileById.get(entry.responsible_id) : undefined;
+                      const department = departmentName(entry.department_id);
+                      const targetLabel = entry.target_date
+                        ? new Date(entry.target_date).toLocaleDateString('de-DE')
+                        : 'Kein Termin';
+
+                      return (
+                        <Box
+                          key={entry.card_id}
+                          sx={{
+                            border: '1px solid',
+                            borderColor: 'divider',
+                            borderRadius: 2,
+                            p: 2,
+                          }}
+                        >
+                          <Stack
+                            direction={{ xs: 'column', md: 'row' }}
+                            spacing={2}
+                            justifyContent="space-between"
+                            alignItems={{ xs: 'flex-start', md: 'center' }}
+                          >
+                            <Box>
+                              <Typography variant="subtitle2">
+                                {entry.project_code || entry.project_name
+                                  ? `${entry.project_code ?? ''}${entry.project_code && entry.project_name ? ' – ' : ''}${entry.project_name ?? ''}`
+                                  : entry.title}
+                              </Typography>
+                              {entry.stage && (
+                                <Typography variant="body2" color="text.secondary">
+                                  Phase: {entry.stage}
+                                </Typography>
+                              )}
+                            </Box>
+                            <Stack direction="row" spacing={2} alignItems="center">
+                              <Tooltip title="Fortschritt (Bearbeitung im Popup)">
+                                <Box>
+                                  <CompletionDial steps={entry.completion_steps ?? 0} onClick={() => {}} disabled />
+                                </Box>
+                              </Tooltip>
+                              <Button
+                                variant="outlined"
+                                onClick={() => openEscalationEditor(entry)}
+                                disabled={!canEditEscalations || !escalationSchemaReady}
+                              >
+                                Bearbeiten
+                              </Button>
+                            </Stack>
+                          </Stack>
+
+                          <Grid container spacing={2} sx={{ mt: 1 }}>
+                            <Grid item xs={12} md={6}>
+                              <Typography variant="caption" color="text.secondary">
+                                Grund
+                              </Typography>
+                              <Typography variant="body2">
+                                {entry.reason || 'Kein Grund hinterlegt.'}
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={12} md={6}>
+                              <Typography variant="caption" color="text.secondary">
+                                Maßnahme
+                              </Typography>
+                              <Typography variant="body2">
+                                {entry.measure || 'Keine Maßnahme hinterlegt.'}
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={12} md={4}>
+                              <Typography variant="caption" color="text.secondary">
+                                Abteilung
+                              </Typography>
+                              <Typography variant="body2">
+                                {department || 'Keine Abteilung zugewiesen.'}
+                              </Typography>
+                            </Grid>
+                            <Grid item xs={12} md={4}>
+                              <Typography variant="caption" color="text.secondary">
+                                Verantwortung
+                              </Typography>
+                              <Typography variant="body2">
+                                {responsible
+                                  ? `${responsible.full_name || responsible.email}${responsible.company ? ` • ${responsible.company}` : ''}`
+                                  : 'Keine Verantwortung zugewiesen.'}
+                              </Typography>
+                            </Grid>
+                          <Grid item xs={12} md={4}>
+                            <Typography variant="caption" color="text.secondary">
+                              Zieltermin
+                            </Typography>
+                            <Typography variant="body2">
+                              {targetLabel}
+                            </Typography>
+                          </Grid>
+                        </Grid>
+                        {(() => {
+                          const historyEntries = escalationHistory[entry.card_id] ?? [];
+                          if (!historyEntries.length) {
+                            return null;
+                          }
+                          const profileLookup = new Map(profiles.map(profile => [profile.id, profile]));
+                          return (
+                            <Box sx={{ mt: 1.5 }}>
+                              <Typography variant="caption" color="text.secondary">
+                                Historie
+                              </Typography>
+                              <Stack spacing={0.5} sx={{ mt: 0.5 }}>
+                                {historyEntries.slice(0, 5).map(history => {
+                                  const author = profileLookup.get(history.changed_by ?? '') ?? null;
+                                  const authorLabel = author
+                                    ? author.full_name || author.email || 'Unbekannt'
+                                    : 'Unbekannt';
+                                  const changedAt = new Date(history.changed_at);
+                                  return (
+                                    <Typography key={history.id} variant="body2">
+                                      {changedAt.toLocaleString('de-DE')} – {authorLabel}
+                                    </Typography>
+                                  );
+                                })}
+                                {historyEntries.length > 5 && (
+                                  <Typography variant="caption" color="text.secondary">
+                                    Weitere Einträge im Popup sichtbar.
+                                  </Typography>
+                                )}
+                              </Stack>
+                            </Box>
+                          );
+                        })()}
+                      </Box>
+                    );
+                  })}
+                </Stack>
+              )}
+
+                {category === 'LK' && <Divider sx={{ my: 2 }} />}
+              </Box>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+
+
+      <Dialog open={escalationDialogOpen} onClose={closeEscalationEditor} maxWidth="sm" fullWidth>
+        <DialogTitle>
+          Eskalation bearbeiten
+          {editingEscalation && (
+            <Typography variant="body2" color="text.secondary">
+              {editingEscalation.project_code || editingEscalation.project_name
+                ? `${editingEscalation.project_code ?? ''}${editingEscalation.project_code && editingEscalation.project_name ? ' – ' : ''}${editingEscalation.project_name ?? ''}`
+                : editingEscalation.title}
+            </Typography>
+          )}
+        </DialogTitle>
+        <DialogContent dividers>
+          {escalationDraft ? (
+            <Stack spacing={2}>
+              <TextField
+                label="Grund"
+                value={escalationDraft.reason}
+                onChange={(event) => updateEscalationDraft({ reason: event.target.value })}
+                fullWidth
+                multiline
+                minRows={3}
+                disabled={!canEditEscalations}
+              />
+              <TextField
+                label="Maßnahme"
+                value={escalationDraft.measure}
+                onChange={(event) => updateEscalationDraft({ measure: event.target.value })}
+                fullWidth
+                multiline
+                minRows={3}
+                disabled={!canEditEscalations}
+              />
+              <FormControl fullWidth size="small" disabled={!canEditEscalations}>
+                <InputLabel>Abteilung</InputLabel>
+                <Select
+                  value={escalationDraft.department_id ?? ''}
+                  label="Abteilung"
+                  onChange={(event) =>
+                    updateEscalationDraft({
+                      department_id: event.target.value ? String(event.target.value) : null,
+                      responsible_id: null,
+                    })
+                  }
+                >
+                  <MenuItem value="">
+                    <em>Keine</em>
+                  </MenuItem>
+                  {departments.map(department => (
+                    <MenuItem key={department.id} value={department.id}>
+                      {department.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!canEditEscalations}>
+                <InputLabel>Verantwortung</InputLabel>
+                <Select
+                  value={escalationDraft.responsible_id ?? ''}
+                  label="Verantwortung"
+                  onChange={(event) =>
+                    updateEscalationDraft({
+                      responsible_id: event.target.value ? String(event.target.value) : null,
+                    })
+                  }
+                >
+                  <MenuItem value="">
+                    <em>Keine</em>
+                  </MenuItem>
+                  {responsibleOptions(escalationDraft.department_id ?? null).map(option => (
+                    <MenuItem key={option.id} value={option.id}>
+                      {option.full_name || option.email}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <TextField
+                label="Zieltermin"
+                type="date"
+                value={escalationDraft.target_date ?? ''}
+                onChange={(event) => updateEscalationDraft({ target_date: event.target.value || null })}
+                fullWidth
+                disabled={!canEditEscalations}
+                InputLabelProps={{ shrink: true }}
+              />
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Tooltip title="Fortschritt">
+                  <Box>
+                    <CompletionDial
+                      steps={escalationDraft.completion_steps ?? 0}
+                      onClick={cycleDraftCompletion}
+                      disabled={!canEditEscalations}
+                    />
+                  </Box>
+                </Tooltip>
+                <Typography variant="body2">{escalationDraft.completion_steps ?? 0} / 4 Schritte</Typography>
+              </Stack>
+              {escalationHistoryReady && editingEscalation && (
+                (() => {
+                  const historyEntries = escalationHistory[editingEscalation.card_id] ?? [];
+                  if (!historyEntries.length) return null;
+                  const profileLookup = new Map(profiles.map(profile => [profile.id, profile]));
+                  return (
+                    <Box>
+                      <Divider sx={{ my: 1.5 }} />
+                      <Typography variant="subtitle2">Änderungshistorie</Typography>
+                      <List dense>
+                        {historyEntries.map(history => {
+                          const author = profileLookup.get(history.changed_by ?? '') ?? null;
+                          const authorLabel = author
+                            ? author.full_name || author.email || 'Unbekannt'
+                            : 'Unbekannt';
+                          const changedAt = new Date(history.changed_at);
+                          return (
+                            <ListItem key={history.id} sx={{ py: 0 }}>
+                              <Typography variant="body2">
+                                {changedAt.toLocaleString('de-DE')} – {authorLabel}
+                              </Typography>
+                            </ListItem>
+                          );
+                        })}
+                      </List>
+                    </Box>
+                  );
+                })()
+              )}
+            </Stack>
+          ) : (
+            <Typography variant="body2">Keine Eskalation ausgewählt.</Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeEscalationEditor}>Abbrechen</Button>
+          <Button onClick={saveEscalation} variant="contained" disabled={!canEditEscalations}>
+            Speichern
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+}

--- a/src/components/kanban/Board.tsx
+++ b/src/components/kanban/Board.tsx
@@ -10,7 +10,7 @@ export default function Board({ board }: BoardProps) {
   return (
     <Box>
       <Typography variant="h4" component="h1" gutterBottom>
-        {board.title}
+        {board.name}
       </Typography>
       {board.description && (
         <Typography variant="body1" color="text.secondary" gutterBottom sx={{ mb: 3 }}>
@@ -19,7 +19,7 @@ export default function Board({ board }: BoardProps) {
       )}
       
       <Box sx={{ display: 'flex', overflowX: 'auto', pb: 2 }}>
-        {board.columns.map((column) => (
+        {(board.columns ?? []).map((column) => (
           <Column key={column.id} column={column} />
         ))}
       </Box>

--- a/src/components/kanban/BoardSettings.tsx
+++ b/src/components/kanban/BoardSettings.tsx
@@ -199,10 +199,10 @@ export default function BoardSettings({ open, board, onClose, onSave }: BoardSet
                   Zuletzt geändert: {new Date(board.updated_at).toLocaleString('de-DE')}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Spalten: {board.board_columns?.length || 0}
+                  Spalten: {(board.columns?.length ?? 0)}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Karten: {board.board_columns?.reduce((total, col) => total + (col.cards?.length || 0), 0) || 0}
+                  Karten: {(board.columns ?? []).reduce((total, col) => total + (col.cards?.length || 0), 0)}
                 </Typography>
               </Box>
             </Box>
@@ -289,7 +289,7 @@ export default function BoardSettings({ open, board, onClose, onSave }: BoardSet
               </Box>
 
               <List>
-                {board.board_columns?.map((column, index) => (
+                {(board.columns ?? []).map((column, index) => (
                   <ListItem key={column.id} divider>
                     <DragIcon sx={{ mr: 1, color: 'text.secondary' }} />
                     <Box

--- a/src/components/kanban/Column.tsx
+++ b/src/components/kanban/Column.tsx
@@ -1,24 +1,24 @@
 import { Paper, Typography, Box } from '@mui/material';
-import { Column as ColumnType } from '@/types';
+import { BoardColumn } from '@/types';
 import TaskCard from './TaskCard';
 
 interface ColumnProps {
-  column: ColumnType;
+  column: BoardColumn;
 }
 
 export default function Column({ column }: ColumnProps) {
   return (
     <Paper sx={{ p: 2, minHeight: 400, width: 300, mr: 2 }}>
       <Typography variant="h6" component="h2" gutterBottom>
-        {column.title}
+        {column.name}
         <Typography component="span" variant="body2" color="text.secondary" sx={{ ml: 1 }}>
-          ({column.tasks.length})
+          {(column.cards?.length ?? 0)}
         </Typography>
       </Typography>
-      
+
       <Box>
-        {column.tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
+        {(column.cards ?? []).map((card) => (
+          <TaskCard key={card.id} task={card} />
         ))}
       </Box>
     </Paper>

--- a/src/components/kanban/TaskCard.tsx
+++ b/src/components/kanban/TaskCard.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Paper, Typography } from '@mui/material';
+import { Card } from '@/types';
+
+interface TaskCardProps {
+  task: Card;
+}
+
+export default function TaskCard({ task }: TaskCardProps) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Typography variant="subtitle1" component="h3">
+        {task.title}
+      </Typography>
+      {task.description && (
+        <Typography variant="body2" color="text.secondary">
+          {task.description}
+        </Typography>
+      )}
+    </Paper>
+  );
+}

--- a/src/components/kanban/original/KanbanCard.tsx
+++ b/src/components/kanban/original/KanbanCard.tsx
@@ -1,0 +1,616 @@
+'use client';
+
+import { ReactNode, useMemo } from 'react';
+import { Box, Chip, IconButton, Typography } from '@mui/material';
+import { Draggable } from '@hello-pangea/dnd';
+
+import { nullableDate, toBoolean } from '@/utils/booleans';
+
+export type KanbanDensity = 'compact' | 'xcompact' | 'large';
+
+export interface KanbanCardProps {
+  card: any;
+  index: number;
+  density: KanbanDensity;
+  rows: any[];
+  setRows: (rows: any[]) => void;
+  saveCards: () => Promise<boolean | void> | boolean | void;
+  setSelectedCard: (card: any) => void;
+  setEditModalOpen: (open: boolean) => void;
+  setEditTabValue: (value: number) => void;
+  inferStage: (card: any) => string;
+  idFor: (card: any) => string;
+  users: Array<{
+    id: string;
+    name?: string;
+    full_name?: string;
+    email?: string;
+    department?: string | null;
+    company?: string | null;
+  }>;
+  canModify: boolean;
+}
+
+const statusKeys = ['message', 'qualitaet', 'kosten', 'termine'];
+
+export function KanbanCard({
+  card,
+  index,
+  density,
+  rows,
+  setRows,
+  saveCards,
+  setSelectedCard,
+  setEditModalOpen,
+  setEditTabValue,
+  inferStage,
+  idFor,
+  users,
+  canModify,
+}: KanbanCardProps) {
+  const cardId = idFor(card);
+  const stage = inferStage(card);
+  const isDragDisabled = !canModify;
+
+  const usersById = useMemo(() => {
+    const map = new Map<string, any>();
+    users.forEach((user) => {
+      if (user && user.id) {
+        map.set(String(user.id), user);
+      }
+    });
+    return map;
+  }, [users]);
+
+  const escalation = String(card.Eskalation || '').trim().toUpperCase();
+  const hasLKEscalation = escalation === 'LK';
+  const hasSKEscalation = escalation === 'SK';
+
+  let statusKurz = '';
+  if (Array.isArray(card.StatusHistory) && card.StatusHistory.length) {
+    const latest = card.StatusHistory[0];
+    statusKeys.some((key) => {
+      const entry = latest[key as keyof typeof latest] as any;
+      if (entry && entry.text && entry.text.trim()) {
+        statusKurz = entry.text.trim();
+        return true;
+      }
+      return false;
+    });
+  } else {
+    statusKurz = String(card['Status Kurz'] || '').trim();
+  }
+
+  const dueDate = nullableDate(card['Due Date']);
+  const trCompleted = toBoolean(card['TR_Completed']);
+  const isOverdue = !!dueDate && !trCompleted && dueDate < new Date();
+  const trOriginalDate = nullableDate(card['TR_Datum']);
+  const trCompletedDate = nullableDate(card['TR_Completed_At'] || card['TR_Completed_Date']);
+  const trCompletionDiff = trOriginalDate && trCompletedDate
+    ? Math.round((trCompletedDate.getTime() - trOriginalDate.getTime()) / (1000 * 60 * 60 * 24))
+    : null;
+  const hasPriority = toBoolean(card['Priorität']);
+  const sopDate = nullableDate(card['SOP_Datum']);
+
+  let currentSize: KanbanDensity = density;
+  if (card['Collapsed'] === 'large') {
+    currentSize = 'large';
+  } else if (card['Collapsed'] === 'compact') {
+    currentSize = 'compact';
+  }
+
+  let backgroundColor = 'white';
+  if (hasLKEscalation) backgroundColor = '#fff3e0';
+  if (hasSKEscalation) backgroundColor = '#ffebee';
+
+  let borderColor = 'var(--line)';
+  if (hasLKEscalation) borderColor = '#ef6c00';
+  if (hasSKEscalation) borderColor = '#c62828';
+
+  const ampelColor = hasLKEscalation || hasSKEscalation ? '#ff5a5a' : '#14c38e';
+
+  const updateCard = (updates: any) => {
+    if (!canModify) {
+      return;
+    }
+    const cardIndex = rows.findIndex((c: any) => idFor(c) === cardId);
+    if (cardIndex >= 0) {
+      const newRows = [...rows];
+      newRows[cardIndex] = { ...newRows[cardIndex], ...updates };
+      setRows(newRows);
+
+      setTimeout(() => {
+        saveCards();
+      }, 200);
+    }
+  };
+
+  const handleOpenEdit = () => {
+    if (!canModify) {
+      return;
+    }
+    setSelectedCard(card);
+    setEditModalOpen(true);
+    setEditTabValue(1);
+  };
+
+  const renderTRChip = (label: string, value: string | Date, color: string, border: string, background: string): ReactNode => {
+    if (!value) return null;
+    const date = new Date(value);
+    return (
+      <Chip
+        label={`${label}: ${date.toLocaleDateString('de-DE')}`}
+        size="small"
+        sx={{
+          fontSize: '10px',
+          height: '18px',
+          backgroundColor: background,
+          color,
+          border,
+          '& .MuiChip-label': {
+            px: 0.8,
+            py: 0,
+          },
+        }}
+      />
+    );
+  };
+
+  return (
+    <Draggable key={cardId} draggableId={cardId} index={index} isDragDisabled={isDragDisabled}>
+      {(provided, snapshot) => (
+        <Box
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          className={`card ${hasLKEscalation ? 'esk-lk' : ''} ${hasSKEscalation ? 'esk-sk' : ''}`}
+          onClick={(e) => {
+            if (!canModify) {
+              return;
+            }
+            if (!(e.target as HTMLElement).closest('.controls')) {
+              setSelectedCard(card);
+              setEditModalOpen(true);
+              setEditTabValue(1);
+            }
+          }}
+          sx={{
+            backgroundColor,
+            border: `1px solid ${borderColor}`,
+            borderRadius: currentSize === 'xcompact' ? '4px' : '12px',
+            padding: currentSize === 'xcompact' ? '4px' : '10px',
+            cursor: 'pointer',
+            transition: 'transform 0.12s ease, box-shadow 0.12s ease',
+            opacity: snapshot.isDragging ? 0.96 : 1,
+            transform: snapshot.isDragging ? 'rotate(2deg) scale(1.03)' : 'none',
+            boxShadow: snapshot.isDragging
+              ? '0 14px 28px rgba(0,0,0,0.30)'
+              : '0 3px 8px rgba(0,0,0,0.06)',
+            minHeight:
+              currentSize === 'xcompact' ? '18px' : currentSize === 'large' ? '150px' : '80px',
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            '&:hover': {
+              transform: snapshot.isDragging ? 'rotate(2deg) scale(1.03)' : 'translateY(-2px)',
+              boxShadow: '0 6px 14px rgba(0,0,0,0.18)',
+            },
+          }}
+          title={statusKurz || ''}
+        >
+          {currentSize === 'xcompact' ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+                width: '100%',
+                gap: 0.5,
+                padding: '2px',
+              }}
+            >
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '2px',
+                  backgroundColor: ampelColor,
+                  border: '1px solid var(--line)',
+                  flexShrink: 0,
+                }}
+              />
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 600,
+                  color: 'var(--ink)',
+                  fontSize: '10px',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {card['Nummer']}
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  mb: 0.5,
+                }}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Box
+                    sx={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: '50%',
+                      backgroundColor: ampelColor,
+                      border: '1px solid var(--line)',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Typography
+                    variant="subtitle2"
+                    sx={{
+                      fontWeight: 700,
+                      fontSize: '14px',
+                      color: 'var(--ink)',
+                    }}
+                  >
+                    {card['Nummer']}
+                  </Typography>
+                </Box>
+
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  {hasPriority && (
+                    <Chip
+                      label="!"
+                      size="small"
+                      color="error"
+                      sx={{
+                        fontWeight: 700,
+                        height: 20,
+                        '& .MuiChip-label': {
+                          px: 0.75,
+                          fontSize: '12px',
+                        },
+                      }}
+                    />
+                  )}
+                  <Box className="controls" sx={{ display: 'flex', gap: 0.5 }}>
+                  <IconButton
+                    size="small"
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      fontSize: '10px',
+                      border: '1px solid var(--line)',
+                      backgroundColor: currentSize === 'large' ? '#e3f2fd' : 'transparent',
+                      color: currentSize === 'large' ? '#1976d2' : 'var(--muted)',
+                      '&:hover': { backgroundColor: 'rgba(0,0,0,0.06)' },
+                    }}
+                    title="Groß/Normal umschalten"
+                    disabled={!canModify}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const newSize = currentSize === 'large' ? '' : 'large';
+                      updateCard({ Collapsed: newSize });
+                    }}
+                  >
+                    ↕
+                  </IconButton>
+
+                  <IconButton
+                    size="small"
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      fontSize: '9px',
+                      border: '1px solid var(--line)',
+                      backgroundColor: hasLKEscalation ? '#ef6c00' : 'transparent',
+                      color: hasLKEscalation ? 'white' : 'var(--muted)',
+                      '&:hover': {
+                        backgroundColor: hasLKEscalation ? '#e65100' : 'rgba(0,0,0,0.06)',
+                      },
+                    }}
+                    title="Leitungskreis"
+                    disabled={!canModify}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const newEskalation = hasLKEscalation ? '' : 'LK';
+                      const newAmpel = newEskalation ? 'rot' : 'grün';
+                      updateCard({
+                        Eskalation: newEskalation,
+                        Ampel: newAmpel,
+                      });
+                    }}
+                  >
+                    LK
+                  </IconButton>
+
+                  <IconButton
+                    size="small"
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      fontSize: '9px',
+                      border: '1px solid var(--line)',
+                      backgroundColor: hasSKEscalation ? '#c62828' : 'transparent',
+                      color: hasSKEscalation ? 'white' : 'var(--muted)',
+                      '&:hover': {
+                        backgroundColor: hasSKEscalation ? '#b71c1c' : 'rgba(0,0,0,0.06)',
+                      },
+                    }}
+                    title="Strategiekreis"
+                    disabled={!canModify}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      const newEskalation = hasSKEscalation ? '' : 'SK';
+                      const newAmpel = newEskalation ? 'rot' : 'grün';
+                      updateCard({
+                        Eskalation: newEskalation,
+                        Ampel: newAmpel,
+                      });
+                    }}
+                  >
+                    SK
+                  </IconButton>
+
+                  <IconButton
+                    size="small"
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      fontSize: '10px',
+                      border: '1px solid var(--line)',
+                      backgroundColor: 'transparent',
+                      color: 'var(--muted)',
+                      '&:hover': { backgroundColor: 'rgba(0,0,0,0.06)' },
+                    }}
+                    title="Bearbeiten"
+                    disabled={!canModify}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleOpenEdit();
+                    }}
+                  >
+                    ✎
+                  </IconButton>
+                  </Box>
+                </Box>
+              </Box>
+
+              {card['Teil'] && (
+                <Typography
+                  variant="body2"
+                  sx={{
+                    fontSize: '12px',
+                    lineHeight: 1.3,
+                    color: 'var(--muted)',
+                    overflow: 'hidden',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    mb: 1,
+                  }}
+                >
+                  {card['Teil']}
+                </Typography>
+              )}
+
+              {statusKurz && (
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: '12px',
+                    color: 'var(--muted)',
+                    overflow: 'hidden',
+                    textOverflow: currentSize === 'large' ? 'clip' : 'ellipsis',
+                    whiteSpace: currentSize === 'large' ? 'pre-wrap' : 'nowrap',
+                    display: currentSize === 'large' ? '-webkit-box' : 'block',
+                    WebkitLineClamp: currentSize === 'large' ? 6 : undefined,
+                    WebkitBoxOrient: currentSize === 'large' ? 'vertical' : undefined,
+                    mb: 0.5,
+                    wordBreak: currentSize === 'large' ? 'break-word' : 'normal',
+                  }}
+                >
+                  {statusKurz}
+                </Typography>
+              )}
+
+              {currentSize === 'large' && card['Bild'] && (
+                <Box sx={{ mb: 1, display: 'flex', justifyContent: 'center' }}>
+                  <img
+                    src={card['Bild']}
+                    alt="Projektbild"
+                    style={{
+                      maxWidth: '100%',
+                      maxHeight: '60px',
+                      borderRadius: '6px',
+                      objectFit: 'cover',
+                    }}
+                  />
+                </Box>
+              )}
+
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  mt: 'auto',
+                  fontSize: '10px',
+                }}
+              >
+                <Typography variant="caption" sx={{ fontSize: '10px', color: 'var(--muted)' }}>
+                  {card['Verantwortlich'] || ''}
+                </Typography>
+
+                {dueDate && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      fontSize: '9px',
+                      color: isOverdue ? '#d32f2f' : 'var(--muted)',
+                      fontWeight: isOverdue ? 600 : 400,
+                      backgroundColor: isOverdue ? '#ffebee' : 'transparent',
+                      padding: isOverdue ? '2px 4px' : '0',
+                      borderRadius: isOverdue ? '4px' : '0',
+                    }}
+                  >
+                    {dueDate.toLocaleDateString('de-DE')}
+                  </Typography>
+                )}
+              </Box>
+
+              {(card['TR_Datum'] || card['TR_Neu'] || sopDate) && (
+                <Box
+                  sx={{
+                    mt: 1,
+                    pt: 1,
+                    borderTop: '1px solid var(--line)',
+                    display: 'flex',
+                    justifyContent: sopDate ? 'space-between' : 'center',
+                    gap: 0.5,
+                    alignItems: 'center',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+                    {renderTRChip(
+                      'TR',
+                      card['TR_Datum'],
+                      '#2e7d32',
+                      '1px solid #c8e6c9',
+                      '#e8f5e8',
+                    )}
+                    {renderTRChip(
+                      'TR neu',
+                      card['TR_Neu'],
+                      '#1976d2',
+                      '1px solid #bbdefb',
+                      '#e3f2fd',
+                    )}
+                  </Box>
+                  {sopDate && (
+                    <Chip
+                      label={`SOP: ${sopDate.toLocaleDateString('de-DE')}`}
+                      size="small"
+                      sx={{
+                        fontSize: '10px',
+                        height: '18px',
+                        backgroundColor: '#f3e5f5',
+                        color: '#6a1b9a',
+                        border: '1px solid #e1bee7',
+                        '& .MuiChip-label': {
+                          px: 0.8,
+                          py: 0,
+                        },
+                      }}
+                    />
+                  )}
+                </Box>
+              )}
+
+              {(card['TR_Neu'] || card['TR_Datum']) && trCompleted && (
+                <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                  <Chip label="✓ TR erledigt" size="small" color="success" />
+                  <Typography
+                    variant="caption"
+                    sx={{ display: 'block', color: '#2e7d32', fontWeight: 500 }}
+                  >
+                    Abschluss: {trCompletedDate ? trCompletedDate.toLocaleDateString('de-DE') : 'Datum unbekannt'}
+                    {trCompletionDiff !== null ? ` (${trCompletionDiff >= 0 ? '+' : ''}${trCompletionDiff} Tage)` : ''}
+                  </Typography>
+                </Box>
+              )}
+
+              {currentSize === 'large' &&
+                card['Team'] &&
+                Array.isArray(card['Team']) &&
+                card['Team'].length > 0 && (
+                  <Box sx={{ mt: 1, pt: 1, borderTop: '1px solid var(--line)' }}>
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontSize: '10px',
+                        color: 'var(--muted)',
+                        fontWeight: 600,
+                        display: 'block',
+                        mb: 0.5,
+                      }}
+                    >
+                      Team ({card['Team'].filter((m: any) => m.userId || m.name).length}):
+                    </Typography>
+
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                      {card['Team']
+                        .filter((member: any) => member.userId || member.name)
+                        .map((member: any, idx: number) => {
+                          const roleColors: Record<string, string> = {
+                            entwickler: '#2196f3',
+                            designer: '#9c27b0',
+                            manager: '#ff9800',
+                            tester: '#4caf50',
+                          };
+                          const roleKey = String(member.role || '').toLowerCase();
+                          const roleColor = roleColors[roleKey] || '#757575';
+
+                          const lookupUser = member.userId
+                            ? usersById.get(String(member.userId))
+                            : undefined;
+                          const resolvedName =
+                            (lookupUser?.full_name || lookupUser?.name || '').trim() ||
+                            (member.name || '').trim();
+                          const fallbackEmail = lookupUser?.email || member.email || '';
+                          const displayName =
+                            resolvedName ||
+                            (fallbackEmail ? fallbackEmail.split('@')[0] : 'Unbekannt');
+                          const department =
+                            lookupUser?.department ||
+                            lookupUser?.company ||
+                            member.department ||
+                            member.company ||
+                            '';
+                          const labelParts = [displayName];
+                          if (department) {
+                            labelParts.push(`– ${department}`);
+                          }
+                          if (member.role) {
+                            labelParts.push(`(${member.role})`);
+                          }
+                          const label = labelParts.join(' ');
+
+                          return (
+                            <Chip
+                              key={idx}
+                              label={label}
+                              size="small"
+                              sx={{
+                                fontSize: '8px',
+                                height: 18,
+                                backgroundColor: `${roleColor}20`,
+                                color: roleColor,
+                                border: `1px solid ${roleColor}`,
+                                '& .MuiChip-label': {
+                                  px: 1,
+                                  py: 0,
+                                  fontWeight: 500,
+                                },
+                              }}
+                            />
+                          );
+                        })}
+                    </Box>
+                  </Box>
+                )}
+            </>
+          )}
+        </Box>
+      )}
+    </Draggable>
+  );
+}

--- a/src/components/kanban/original/KanbanDialogs.tsx
+++ b/src/components/kanban/original/KanbanDialogs.tsx
@@ -1,0 +1,1009 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { toBoolean } from '@/utils/booleans';
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  List,
+  ListItem,
+  MenuItem,
+  Select,
+  Tab,
+  Tabs,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+export interface EditCardDialogProps {
+  selectedCard: any | null;
+  editModalOpen: boolean;
+  setEditModalOpen: (open: boolean) => void;
+  editTabValue: number;
+  setEditTabValue: (value: number) => void;
+  rows: any[];
+  setRows: (rows: any[]) => void;
+  users: any[];
+  lanes: string[];
+  checklistTemplates: Record<string, string[]>;
+  inferStage: (card: any) => string;
+  addStatusEntry: (card: any) => void;
+  updateStatusSummary: (card: any) => void;
+  handleTRNeuChange: (card: any, newDate: string) => void;
+  saveCards: () => void;
+  idFor: (card: any) => string;
+  setSelectedCard: (card: any) => void;
+}
+
+export function EditCardDialog({
+  selectedCard,
+  editModalOpen,
+  setEditModalOpen,
+  editTabValue,
+  setEditTabValue,
+  rows,
+  setRows,
+  users,
+  lanes,
+  checklistTemplates,
+  inferStage,
+  addStatusEntry,
+  updateStatusSummary,
+  handleTRNeuChange,
+  saveCards,
+  idFor,
+  setSelectedCard,
+}: EditCardDialogProps) {
+  if (!selectedCard) return null;
+
+  const stage = inferStage(selectedCard);
+  const tasks = checklistTemplates[stage] || [];
+  const stageChecklist = (selectedCard.ChecklistDone && selectedCard.ChecklistDone[stage]) || {};
+
+  return (
+    <Dialog
+      open={editModalOpen}
+      onClose={() => setEditModalOpen(false)}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          backgroundColor: 'background.paper',
+          color: 'text.primary',
+        },
+      }}
+    >
+      <DialogTitle
+        sx={{
+          borderBottom: 1,
+          borderColor: 'divider',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="h6">
+          Karte bearbeiten: {selectedCard['Nummer']} - {selectedCard['Teil']}
+        </Typography>
+        <IconButton onClick={() => setEditModalOpen(false)}>×</IconButton>
+      </DialogTitle>
+
+      <DialogContent sx={{ p: 0 }}>
+        <Tabs value={editTabValue} onChange={(e, v) => setEditTabValue(v)}>
+          <Tab label="Details" />
+          <Tab label="Status & Checkliste" />
+          <Tab label="Team" />
+        </Tabs>
+
+        {editTabValue === 0 && (
+          <Box sx={{ p: 3 }}>
+            <Box
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: 'auto 1fr auto 1fr auto 1fr',
+                gap: 2,
+                alignItems: 'center',
+                mb: 3,
+              }}
+            >
+              <Typography>Nummer</Typography>
+              <TextField
+                size="small"
+                value={selectedCard['Nummer'] || ''}
+                onChange={(e) => {
+                  selectedCard['Nummer'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              />
+
+              <Typography>Name</Typography>
+              <TextField
+                size="small"
+                value={selectedCard['Teil'] || ''}
+                onChange={(e) => {
+                  selectedCard['Teil'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              />
+
+              <Typography>Verantwortlich</Typography>
+              <Select
+                size="small"
+                value={selectedCard['Verantwortlich'] || ''}
+                onChange={(e) => {
+                  selectedCard['Verantwortlich'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              >
+                <MenuItem value="">
+                  <em>Nicht zugewiesen</em>
+                </MenuItem>
+                {users.map((user: any) => (
+                  <MenuItem key={user.id || user.email} value={user.full_name || user.name || user.email}>
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {(user.full_name || user.name || user.email) ?? 'Unbekannt'}
+                        {user.department || user.company ? ` – ${user.department || user.company}` : ''}
+                      </Typography>
+                      {user.email && (
+                        <Typography variant="caption" color="text.secondary">
+                          {user.email}
+                        </Typography>
+                      )}
+                    </Box>
+                  </MenuItem>
+                ))}
+              </Select>
+
+              <Typography>Fällig bis</Typography>
+              <TextField
+                size="small"
+                type="date"
+                value={String(selectedCard['Due Date'] || '').slice(0, 10)}
+                onChange={(e) => {
+                  selectedCard['Due Date'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              />
+
+              <Typography>Priorität</Typography>
+              <Checkbox
+                checked={toBoolean(selectedCard['Priorität'])}
+                onChange={(e) => {
+                  selectedCard['Priorität'] = e.target.checked;
+                  setRows([...rows]);
+                  setTimeout(() => saveCards(), 500);
+                }}
+              />
+
+              <Typography>SOP</Typography>
+              <TextField
+                size="small"
+                type="date"
+                value={String(selectedCard['SOP_Datum'] || '').slice(0, 10)}
+                onChange={(e) => {
+                  selectedCard['SOP_Datum'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              />
+
+              <Typography>Swimlane</Typography>
+              <Select
+                size="small"
+                value={selectedCard['Swimlane'] || ''}
+                onChange={(e) => {
+                  selectedCard['Swimlane'] = e.target.value;
+                  setRows([...rows]);
+                }}
+              >
+                {lanes.map((lane) => (
+                  <MenuItem key={lane} value={lane}>
+                    {lane}
+                  </MenuItem>
+                ))}
+              </Select>
+
+              <Typography>Bild</Typography>
+              <TextField
+                size="small"
+                type="file"
+                inputProps={{ accept: 'image/*' }}
+                onChange={(e) => {
+                  const file = (e.target as HTMLInputElement).files?.[0];
+                  if (file) {
+                    const reader = new FileReader();
+                    reader.onload = (ev) => {
+                      selectedCard['Bild'] = ev.target?.result;
+                      setRows([...rows]);
+                    };
+                    reader.readAsDataURL(file);
+                  }
+                }}
+              />
+            </Box>
+
+            {selectedCard['Bild'] && (
+              <Box sx={{ mb: 2 }}>
+                <img
+                  src={selectedCard['Bild']}
+                  alt="Karten-Bild"
+                  style={{ maxWidth: '300px', width: '100%', height: 'auto', borderRadius: '8px' }}
+                />
+              </Box>
+            )}
+          </Box>
+        )}
+
+        {editTabValue === 1 && (
+          <Box sx={{ p: 3 }}>
+            <Box sx={{ mb: 4 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                <Typography variant="h6">Statushistorie</Typography>
+                <Button variant="outlined" size="small" onClick={() => addStatusEntry(selectedCard)}>
+                  🕓 Neuer Eintrag
+                </Button>
+              </Box>
+
+              <Box sx={{ maxHeight: '300px', overflow: 'auto', mb: 3 }}>
+                {(selectedCard.StatusHistory || []).map((entry: any, idx: number) => (
+                  <Box key={idx} sx={{ mb: 3, border: 1, borderColor: 'divider', borderRadius: 1, p: 2 }}>
+                    <Table size="small">
+                      <TableHead>
+                        <TableRow>
+                          <TableCell sx={{ fontWeight: 600 }}>{entry.date || 'Datum'}</TableCell>
+                          <TableCell colSpan={2}>
+                            <TextField
+                              size="small"
+                              fullWidth
+                              multiline
+                              minRows={1}
+                              maxRows={3}
+                              placeholder="Statusmeldung"
+                              value={entry.message?.text || ''}
+                              onChange={(e) => {
+                                if (!entry.message) entry.message = { text: '', escalation: false };
+                                entry.message.text = e.target.value;
+                                updateStatusSummary(selectedCard);
+                                setRows([...rows]);
+                              }}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      </TableHead>
+                      <TableBody>
+                        {['qualitaet', 'kosten', 'termine'].map((key) => {
+                          const labels: Record<string, string> = {
+                            qualitaet: 'Qualität',
+                            kosten: 'Kosten',
+                            termine: 'Termine',
+                          };
+                          const val = entry[key] || { text: '', escalation: false };
+
+                          return (
+                            <TableRow key={key}>
+                              <TableCell>{labels[key]}</TableCell>
+                              <TableCell>
+                                <TextField
+                                  size="small"
+                                  fullWidth
+                                  multiline
+                                  minRows={1}
+                                  maxRows={4}
+                                  value={val.text || ''}
+                                  onChange={(e) => {
+                                    if (!entry[key]) entry[key] = { text: '', escalation: false };
+                                    entry[key].text = e.target.value;
+                                    updateStatusSummary(selectedCard);
+                                    setRows([...rows]);
+                                  }}
+                                  sx={{
+                                    '& .MuiInputBase-root': {
+                                      alignItems: 'flex-start',
+                                    },
+                                  }}
+                                />
+                              </TableCell>
+                              <TableCell>
+                                <FormControlLabel
+                                  control={
+                                    <Checkbox
+                                      size="small"
+                                      checked={val.escalation || false}
+                                      onChange={(e) => {
+                                        if (!entry[key]) entry[key] = { text: '', escalation: false };
+                                        entry[key].escalation = e.target.checked;
+                                        updateStatusSummary(selectedCard);
+                                        setRows([...rows]);
+                                      }}
+                                    />
+                                  }
+                                  label="Eskalation"
+                                />
+                              </TableCell>
+                            </TableRow>
+                          );
+                        })}
+                      </TableBody>
+                    </Table>
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+
+            <Box>
+              <Typography variant="h6" sx={{ mb: 2 }}>
+                Checkliste für Phase: {stage}
+              </Typography>
+              <List>
+                {tasks.map((task) => {
+                  const checked = stageChecklist[task];
+                  return (
+                    <ListItem key={task} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Checkbox
+                        checked={Boolean(checked)}
+                        onChange={(e) => {
+                          if (!selectedCard.ChecklistDone) selectedCard.ChecklistDone = {};
+                          if (!selectedCard.ChecklistDone[stage]) selectedCard.ChecklistDone[stage] = {};
+                          selectedCard.ChecklistDone[stage][task] = e.target.checked;
+                          setRows([...rows]);
+                        }}
+                      />
+                      <Typography variant="body2">{task}</Typography>
+                    </ListItem>
+                  );
+                })}
+              </List>
+            </Box>
+
+            <Box sx={{ mt: 3 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                TR-Datum (Original)
+              </Typography>
+              {selectedCard['TR_Datum'] ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                    p: 1,
+                    backgroundColor: 'action.hover',
+                    borderRadius: 1,
+                  }}
+                >
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {new Date(selectedCard['TR_Datum']).toLocaleDateString('de-DE')}
+                  </Typography>
+                  <Chip label="Gesperrt" size="small" color="default" sx={{ fontSize: '10px' }} />
+                </Box>
+              ) : (
+                <TextField
+                  size="small"
+                  type="date"
+                  value={selectedCard['TR_Datum'] || ''}
+                  onChange={(e) => {
+                    if (e.target.value && !selectedCard['TR_Datum']) {
+                      selectedCard['TR_Datum'] = e.target.value;
+                      setRows([...rows]);
+                    }
+                  }}
+                  helperText="Kann nach Eingabe nicht mehr geändert werden"
+                  InputLabelProps={{ shrink: true }}
+                />
+              )}
+
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  TR neu
+                </Typography>
+                <TextField
+                  size="small"
+                  type="date"
+                  value={selectedCard['TR_Neu'] || ''}
+                  onChange={(e) => handleTRNeuChange(selectedCard, e.target.value)}
+                  InputLabelProps={{ shrink: true }}
+                />
+              </Box>
+
+              <TextField
+                label="TR-Datum"
+                type="date"
+                value={(selectedCard && (selectedCard['TR_Neu'] || selectedCard['TR_Datum'])) || ''}
+                onChange={(e) => {
+                  const newCard = { ...selectedCard };
+                  newCard['TR_Neu'] = e.target.value;
+                  setSelectedCard(newCard);
+                }}
+                InputLabelProps={{ shrink: true }}
+                sx={{ mt: 2, mb: 2 }}
+              />
+
+              {(selectedCard['TR_Neu'] || selectedCard['TR_Datum']) && (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={toBoolean(selectedCard['TR_Completed'])}
+                      onChange={(e) => {
+                        const checked = e.target.checked;
+                        const completionTimestamp = checked ? new Date().toISOString() : null;
+                        const newCard = { ...selectedCard, TR_Completed: checked };
+                        newCard['TR_Completed_At'] = completionTimestamp;
+                        newCard['TR_Completed_Date'] = completionTimestamp;
+                        setSelectedCard(newCard);
+
+                        const index = rows.findIndex((row) => idFor(row) === idFor(selectedCard));
+                        if (index >= 0) {
+                          const updatedRows = [...rows];
+                          updatedRows[index] = {
+                            ...updatedRows[index],
+                            TR_Completed: checked,
+                            TR_Completed_At: completionTimestamp,
+                            TR_Completed_Date: completionTimestamp,
+                          };
+                          setRows(updatedRows);
+                          setTimeout(() => saveCards(), 500);
+                        }
+                      }}
+                      sx={{
+                        color: 'success.main',
+                        '&.Mui-checked': {
+                          color: 'success.main',
+                        },
+                      }}
+                    />
+                  }
+                  label="TR abgeschlossen"
+                  sx={{ mt: 1, mb: 2 }}
+                />
+              )}
+
+              {(selectedCard['TR_Datum'] || selectedCard['TR_Neu'] || (selectedCard['TR_History'] && selectedCard['TR_History'].length > 0)) && (
+                <Box sx={{ mt: 2, pt: 2, borderTop: '1px solid var(--line)' }}>
+                  <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+                    TR-Termine
+                  </Typography>
+
+                  {selectedCard['TR_Datum'] && (
+                    <Typography variant="body2" sx={{ fontWeight: 600, color: '#4caf50', mb: 0.5 }}>
+                      TR ursprünglich: {new Date(selectedCard['TR_Datum']).toLocaleDateString('de-DE')}
+                    </Typography>
+                  )}
+
+                  {(() => {
+                    const history = selectedCard['TR_History'] || [];
+                    const currentTRNeu = selectedCard['TR_Neu'];
+                    const uniqueDates = new Set();
+                    const uniqueEntries: any[] = [];
+
+                    history.forEach((entry: any) => {
+                      const entryDate = entry.date;
+                      if (entryDate !== currentTRNeu && !uniqueDates.has(entryDate)) {
+                        uniqueDates.add(entryDate);
+                        uniqueEntries.push(entry);
+                      }
+                    });
+
+                    return (
+                      uniqueEntries.length > 0 && (
+                        <Box sx={{ mb: 1 }}>
+                          {uniqueEntries.map((trEntry: any, idx: number) => (
+                            <Typography
+                              key={`${trEntry.date}-${idx}`}
+                              variant="body2"
+                              sx={{
+                                color: 'var(--muted)',
+                                display: 'block',
+                                textDecoration: 'line-through',
+                                opacity: 0.7,
+                                mb: 0.5,
+                              }}
+                            >
+                              TR geändert: {new Date(trEntry.date).toLocaleDateString('de-DE')}
+                              {trEntry.changedBy && (
+                                <span style={{ fontSize: '12px', marginLeft: '8px' }}>(von {trEntry.changedBy})</span>
+                              )}
+                            </Typography>
+                          ))}
+                        </Box>
+                      )
+                    );
+                  })()}
+
+                  {selectedCard['TR_Neu'] && (
+                    <Typography variant="body2" sx={{ fontWeight: 600, color: '#2196f3' }}>
+                      TR aktuell: {new Date(selectedCard['TR_Neu']).toLocaleDateString('de-DE')}
+                    </Typography>
+                  )}
+                </Box>
+              )}
+            </Box>
+          </Box>
+        )}
+
+        {editTabValue === 2 && (
+          <Box sx={{ p: 3 }}>
+            <Typography variant="h6" sx={{ mb: 2 }}>
+              Team-Mitglieder
+            </Typography>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {(() => {
+                const userList = Array.isArray(users) ? users : [];
+                const userById = new Map<string, any>();
+                userList.forEach((user: any) => {
+                  if (user.id) {
+                    userById.set(user.id, user);
+                  }
+                });
+
+                const formatUserLabel = (user: any) => {
+                  if (!user) return 'Mitglied auswählen';
+                  const baseName = user.full_name || user.name || user.email || 'Unbekannt';
+                  const department = user.department || user.company;
+                  return department ? `${baseName} – ${department}` : baseName;
+                };
+
+                return (selectedCard.Team || []).map((member: any, idx: number) => {
+                  const memberId = `team-member-${idx}`;
+                  const selectedUser = member.userId ? userById.get(member.userId) : null;
+
+                  return (
+                    <Box
+                      key={idx}
+                      sx={{
+                        display: 'grid',
+                        gridTemplateColumns: '3fr 2fr auto',
+                        alignItems: 'flex-start',
+                        gap: 1,
+                        border: '1px solid var(--line)',
+                        borderRadius: 1,
+                        p: 1,
+                      }}
+                    >
+                      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                        <FormControl size="small" fullWidth>
+                          <InputLabel id={`${memberId}-label`}>Mitglied</InputLabel>
+                          <Select
+                            labelId={`${memberId}-label`}
+                            id={memberId}
+                            value={member.userId || ''}
+                            label="Mitglied"
+                            onChange={(e) => {
+                              const userId = String(e.target.value);
+                              if (userId) {
+                                const selected = userById.get(userId) || null;
+                                if (selected) {
+                                  const displayName =
+                                    selected.full_name || selected.name || selected.email || 'Unbekannt';
+                                  selectedCard.Team[idx] = {
+                                    ...selectedCard.Team[idx],
+                                    userId,
+                                    name: displayName,
+                                    email: selected.email || '',
+                                    department: selected.department || selected.company || '',
+                                  };
+                                }
+                              } else {
+                                selectedCard.Team[idx] = {
+                                  ...selectedCard.Team[idx],
+                                  userId: '',
+                                  name: '',
+                                  email: '',
+                                  department: '',
+                                };
+                              }
+                              setRows([...rows]);
+                            }}
+                            renderValue={(selected) => {
+                              if (!selected) return 'Mitglied auswählen';
+                              const user = userById.get(String(selected));
+                              return formatUserLabel(user);
+                            }}
+                          >
+                            <MenuItem value="">
+                              <em>Mitglied auswählen</em>
+                            </MenuItem>
+                            {userList
+                              .filter((user: any) => user.id)
+                              .map((user: any) => (
+                                <MenuItem key={user.id} value={user.id}>
+                                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                                      {user.full_name || user.name || user.email || 'Unbekannt'}
+                                    </Typography>
+                                    {(user.department || user.company) && (
+                                      <Typography variant="caption" color="text.secondary">
+                                        {(user.department || user.company) as string}
+                                      </Typography>
+                                    )}
+                                    {user.email && (
+                                      <Typography variant="caption" color="text.secondary">
+                                        {user.email}
+                                      </Typography>
+                                    )}
+                                  </Box>
+                                </MenuItem>
+                              ))}
+                          </Select>
+                        </FormControl>
+
+                        {selectedUser && (
+                          <Box>
+                            <Typography variant="caption" color="text.secondary">
+                              {selectedUser.email}
+                            </Typography>
+                            {selectedUser.department && (
+                              <Typography variant="caption" color="text.secondary" display="block">
+                                Abteilung: {selectedUser.department}
+                              </Typography>
+                            )}
+                          </Box>
+                        )}
+                      </Box>
+
+                      <TextField
+                        size="small"
+                        label="Rolle"
+                        value={member.role || ''}
+                        onChange={(e) => {
+                          selectedCard.Team[idx].role = e.target.value;
+                          setRows([...rows]);
+                        }}
+                        sx={{ minWidth: 120 }}
+                        placeholder="z.B. Dev, Design..."
+                      />
+
+                      <IconButton
+                        color="error"
+                        size="small"
+                        onClick={() => {
+                          selectedCard.Team.splice(idx, 1);
+                          setRows([...rows]);
+                        }}
+                        title="Mitglied entfernen"
+                        sx={{
+                          flexShrink: 0,
+                          mt: 0.5,
+                          '&:hover': { backgroundColor: 'error.light', color: 'white' },
+                        }}
+                      >
+                        🗑️
+                      </IconButton>
+                    </Box>
+                  );
+                });
+              })()}
+            </Box>
+
+            <Button
+              variant="outlined"
+              onClick={() => {
+                if (!selectedCard.Team) selectedCard.Team = [];
+                selectedCard.Team.push({ userId: '', name: '', email: '', department: '', role: '' });
+                setRows([...rows]);
+              }}
+              sx={{ mt: 1 }}
+            >
+              + Team-Mitglied hinzufügen
+            </Button>
+
+            {selectedCard.Team && selectedCard.Team.length > 0 && (
+              <Box sx={{ mt: 3, p: 2, backgroundColor: 'action.hover', borderRadius: 1 }}>
+                <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                  Team-Übersicht:
+                </Typography>
+                <Typography variant="body2">{selectedCard.Team.length} Mitglieder</Typography>
+                <Typography variant="body2">
+                  Rollen: {Array.from(new Set(selectedCard.Team.map((m: any) => m.role).filter(Boolean))).join(', ')}
+                </Typography>
+                {(() => {
+                  const departments = Array.from(
+                    new Set(
+                      (selectedCard.Team || [])
+                        .map((m: any) => (m.department || m.company || '').toString().trim())
+                        .filter(Boolean),
+                    ),
+                  );
+                  if (!departments.length) return null;
+                  return (
+                    <Typography variant="body2">
+                      Abteilungen: {departments.join(', ')}
+                    </Typography>
+                  );
+                })()}
+              </Box>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ borderTop: 1, borderColor: 'divider', p: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            if (window.confirm(`Soll die Karte "${selectedCard['Nummer']} ${selectedCard['Teil']}" wirklich archiviert werden?`)) {
+              selectedCard['Archived'] = '1';
+              selectedCard['ArchivedDate'] = new Date().toLocaleDateString('de-DE');
+              setRows([...rows]);
+              setEditModalOpen(false);
+              setTimeout(() => saveCards(), 500);
+            }
+          }}
+        >
+          Archivieren
+        </Button>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={() => {
+            if (window.confirm(`Soll die Karte "${selectedCard['Nummer']} – ${selectedCard['Teil']}" wirklich gelöscht werden?`)) {
+              if (window.confirm('Bist Du sicher, dass diese Karte dauerhaft gelöscht werden soll?')) {
+                const idx = rows.findIndex((r) => idFor(r) === idFor(selectedCard));
+                if (idx >= 0) {
+                  rows.splice(idx, 1);
+                  setRows([...rows]);
+                  setEditModalOpen(false);
+                }
+              }
+            }
+          }}
+        >
+          Löschen
+        </Button>
+        <Button variant="contained" onClick={() => setEditModalOpen(false)}>
+          Schließen
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export interface ArchiveDialogProps {
+  archiveOpen: boolean;
+  setArchiveOpen: (open: boolean) => void;
+  archivedCards: any[];
+  restoreCard: (card: any) => void;
+  deleteCardPermanently: (card: any) => void;
+}
+
+export function ArchiveDialog({ archiveOpen, setArchiveOpen, archivedCards, restoreCard, deleteCardPermanently }: ArchiveDialogProps) {
+  return (
+    <Dialog open={archiveOpen} onClose={() => setArchiveOpen(false)} maxWidth="md" fullWidth>
+      <DialogTitle>📦 Archivierte Karten</DialogTitle>
+      <DialogContent>
+        {archivedCards.length === 0 ? (
+          <Typography color="text.secondary">Keine archivierten Karten vorhanden.</Typography>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Nummer</TableCell>
+                <TableCell>Teil</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Verantwortlich</TableCell>
+                <TableCell>Archiviert am</TableCell>
+                <TableCell align="right">Aktionen</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {archivedCards.map((card, index) => (
+                <TableRow key={index}>
+                  <TableCell>{card.Nummer}</TableCell>
+                  <TableCell>{card.Teil}</TableCell>
+                  <TableCell>{card['Status Kurz']}</TableCell>
+                  <TableCell>{card.Verantwortlich}</TableCell>
+                  <TableCell>{card.ArchivedDate || 'Unbekannt'}</TableCell>
+                  <TableCell align="right">
+                    <Button size="small" variant="outlined" onClick={() => restoreCard(card)} sx={{ mr: 1 }}>
+                      ↩️ Wiederherstellen
+                    </Button>
+                    <Button size="small" variant="outlined" color="error" onClick={() => deleteCardPermanently(card)}>
+                      🗑️ Endgültig löschen
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setArchiveOpen(false)}>Schließen</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export interface NewCardDialogProps {
+  newCardOpen: boolean;
+  setNewCardOpen: (open: boolean) => void;
+  cols: { name: string }[];
+  lanes: string[];
+  rows: any[];
+  setRows: (rows: any[]) => void;
+  users: any[];
+}
+
+export function NewCardDialog({ newCardOpen, setNewCardOpen, cols, lanes, rows, setRows, users }: NewCardDialogProps) {
+  const [newCard, setNewCard] = useState(() => ({
+    Nummer: '',
+    Teil: '',
+    'Board Stage': cols[0]?.name || '',
+    'Status Kurz': '',
+    Verantwortlich: '',
+    'Due Date': '',
+    'Priorität': false,
+    SOP_Datum: '',
+    Ampel: 'grün',
+    Swimlane: lanes[0] || 'Allgemein',
+    UID: `uid_${Date.now()}`,
+    TR_Datum: '',
+    TR_Neu: '',
+    TR_History: [] as any[],
+  }));
+
+  const handleSave = () => {
+    if (!newCard.Nummer.trim() || !newCard.Teil.trim()) {
+      alert('Nummer und Teil sind Pflichtfelder!');
+      return;
+    }
+
+    if (rows.some((r) => r.Nummer === newCard.Nummer)) {
+      alert('Diese Nummer existiert bereits!');
+      return;
+    }
+
+    setRows([...rows, { ...newCard }]);
+    setNewCardOpen(false);
+    setNewCard({
+      Nummer: '',
+      Teil: '',
+      'Board Stage': cols[0]?.name || '',
+      'Status Kurz': '',
+      Verantwortlich: '',
+      'Due Date': '',
+      'Priorität': false,
+      SOP_Datum: '',
+      Ampel: 'grün',
+      Swimlane: lanes[0] || 'Allgemein',
+      UID: `uid_${Date.now()}`,
+      TR_Datum: '',
+      TR_Neu: '',
+      TR_History: [],
+    });
+  };
+
+  const availableUsers = useMemo(() => users || [], [users]);
+
+  return (
+    <Dialog open={newCardOpen} onClose={() => setNewCardOpen(false)} maxWidth="sm" fullWidth>
+      <DialogTitle>➕ Neue Karte erstellen</DialogTitle>
+      <DialogContent sx={{ pt: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Nummer *"
+            value={newCard.Nummer}
+            onChange={(e) => setNewCard({ ...newCard, Nummer: e.target.value })}
+          />
+          <TextField
+            label="Teil *"
+            value={newCard.Teil}
+            onChange={(e) => setNewCard({ ...newCard, Teil: e.target.value })}
+          />
+          <FormControl fullWidth>
+            <InputLabel>Phase</InputLabel>
+            <Select
+              value={newCard['Board Stage']}
+              label="Phase"
+              onChange={(e) => setNewCard({ ...newCard, 'Board Stage': e.target.value as string })}
+            >
+              {cols.map((col) => (
+                <MenuItem key={col.name} value={col.name}>
+                  {col.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel>Verantwortlich</InputLabel>
+            <Select
+              value={newCard.Verantwortlich}
+              label="Verantwortlich"
+              onChange={(e) => setNewCard({ ...newCard, Verantwortlich: e.target.value as string })}
+            >
+              <MenuItem value="">
+                <em>Keiner</em>
+              </MenuItem>
+              {availableUsers.map((user: any) => (
+                <MenuItem key={user.id || user.email} value={user.full_name || user.name || user.email}>
+                  <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                      {(user.full_name || user.name || user.email) ?? 'Unbekannt'}
+                      {user.department || user.company ? ` – ${user.department || user.company}` : ''}
+                    </Typography>
+                    {user.email && (
+                      <Typography variant="caption" color="text.secondary">
+                        {user.email}
+                      </Typography>
+                    )}
+                  </Box>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel>Projekt/Kategorie</InputLabel>
+            <Select
+              value={newCard.Swimlane}
+              label="Projekt/Kategorie"
+              onChange={(e) => setNewCard({ ...newCard, Swimlane: e.target.value as string })}
+            >
+              {lanes.map((lane) => (
+                <MenuItem key={lane} value={lane}>
+                  {lane}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField
+            label="Fälligkeitsdatum"
+            type="date"
+            value={newCard['Due Date']}
+            onChange={(e) => setNewCard({ ...newCard, 'Due Date': e.target.value })}
+            InputLabelProps={{ shrink: true }}
+          />
+          <FormControlLabel
+            control={(
+              <Checkbox
+                checked={Boolean(newCard['Priorität'])}
+                onChange={(e) =>
+                  setNewCard({ ...newCard, 'Priorität': e.target.checked })
+                }
+              />
+            )}
+            label="Priorität"
+          />
+          <TextField
+            label="SOP Datum"
+            type="date"
+            value={newCard.SOP_Datum}
+            onChange={(e) => setNewCard({ ...newCard, SOP_Datum: e.target.value })}
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            label="Status"
+            value={newCard['Status Kurz']}
+            onChange={(e) => setNewCard({ ...newCard, 'Status Kurz': e.target.value })}
+            fullWidth
+            multiline
+            rows={2}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setNewCardOpen(false)}>Abbrechen</Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          sx={{ backgroundColor: '#14c38e', '&:hover': { backgroundColor: '#0ea770' } }}
+        >
+          Karte erstellen
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/kanban/original/KanbanViews.tsx
+++ b/src/components/kanban/original/KanbanViews.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { DragDropContext, Droppable, DropResult } from '@hello-pangea/dnd';
+import { Box, IconButton, Typography } from '@mui/material';
+import { KanbanDensity } from './KanbanCard';
+
+export interface KanbanColumnsViewProps {
+  rows: any[];
+  cols: { id: string; name: string; done?: boolean }[];
+  density: KanbanDensity;
+  searchTerm: string;
+  onDragEnd: (result: DropResult) => void;
+  inferStage: (card: any) => string;
+  archiveColumn: (columnName: string) => void;
+  renderCard: (card: any, index: number) => ReactNode;
+  allowDrag: boolean;
+}
+
+export function KanbanColumnsView({
+  rows,
+  cols,
+  density,
+  searchTerm,
+  onDragEnd,
+  inferStage,
+  archiveColumn,
+  renderCard,
+  allowDrag,
+}: KanbanColumnsViewProps) {
+  const filtered = rows.filter(
+    (row) =>
+      !row['Archived'] &&
+      (!searchTerm ||
+        Object.values(row).some((value) =>
+          String(value || '')
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()),
+        )),
+  );
+
+  const handleDragEnd = allowDrag ? onDragEnd : () => {};
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: 1.5,
+          p: 2,
+          overflow: 'auto',
+          alignItems: 'flex-start',
+          minHeight: '100%',
+        }}
+      >
+        {cols.map((col) => {
+          const colCards = filtered.filter((row) => inferStage(row) === col.name);
+          const redCount = colCards.filter((row) => String(row['Ampel'] || '').toLowerCase().startsWith('rot')).length;
+
+          return (
+            <Box
+              key={col.id}
+              sx={{
+                minWidth: 'var(--colw)',
+                width: 'var(--colw)',
+                backgroundColor: 'var(--panel)',
+                border: '1px solid var(--line)',
+                borderRadius: '14px',
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: '55vh',
+              }}
+            >
+              <Box
+                sx={{
+                  position: 'sticky',
+                  top: 0,
+                  backgroundColor: 'var(--panel)',
+                  padding: '10px 12px',
+                  borderBottom: '1px solid var(--line)',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  zIndex: 3,
+                }}
+              >
+                <Box>
+                  <Typography
+                    variant="h6"
+                    sx={{
+                      fontSize: '14px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      color: 'var(--muted)',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {col.name} {col.done && '✓'}
+                  </Typography>
+                  <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 0.5 }}>
+                    <Typography variant="caption" sx={{ color: 'var(--muted)' }}>
+                      ({colCards.length})
+                    </Typography>
+                    {redCount > 0 && (
+                      <Typography variant="caption" sx={{ color: '#ff5a5a' }}>
+                        ● {redCount}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+
+                {col.done && (
+                  <IconButton
+                    size="small"
+                    title="Alle Karten archivieren"
+                    onClick={() => archiveColumn(col.name)}
+                    disabled={!allowDrag}
+                    sx={{
+                      width: 22,
+                      height: 22,
+                      border: '1px solid var(--line)',
+                      backgroundColor: 'transparent',
+                    }}
+                  >
+                    📦
+                  </IconButton>
+                )}
+              </Box>
+
+              <Droppable droppableId={col.name} isDropDisabled={!allowDrag}>
+                {(provided, snapshot) => (
+                  <Box
+                    ref={provided.innerRef}
+                    {...provided.droppableProps}
+                    sx={{
+                      flex: 1,
+                      padding: '8px',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: density === 'xcompact' ? 0 : 1,
+                      minHeight: '200px',
+                      backgroundColor: snapshot.isDraggingOver ? 'rgba(255,255,255,0.06)' : 'transparent',
+                      outline: snapshot.isDraggingOver ? '2px dashed var(--line)' : 'none',
+                      outlineOffset: snapshot.isDraggingOver ? '-4px' : '0',
+                      transition: 'background-color 0.12s ease, outline-color 0.12s ease',
+                    }}
+                  >
+                    {density === 'xcompact' ? (
+                      <Box
+                        sx={{
+                          display: 'grid',
+                          gridTemplateColumns: 'repeat(5, 1fr)',
+                          gap: 0,
+                          gridAutoRows: '18px',
+                        }}
+                      >
+                        {colCards.map((card, cardIndex) => renderCard(card, cardIndex))}
+                      </Box>
+                    ) : (
+                      colCards.map((card, cardIndex) => renderCard(card, cardIndex))
+                    )}
+                    {provided.placeholder}
+                  </Box>
+                )}
+              </Droppable>
+            </Box>
+          );
+        })}
+      </Box>
+    </DragDropContext>
+  );
+}
+
+export interface KanbanSwimlaneViewProps {
+  rows: any[];
+  cols: { name: string }[];
+  searchTerm: string;
+  onDragEnd: (result: DropResult) => void;
+  inferStage: (card: any) => string;
+  renderCard: (card: any, index: number) => ReactNode;
+  allowDrag: boolean;
+}
+
+export function KanbanSwimlaneView({ rows, cols, searchTerm, onDragEnd, inferStage, renderCard, allowDrag }: KanbanSwimlaneViewProps) {
+  const filtered = rows.filter(
+    (row) =>
+      !row['Archived'] &&
+      (!searchTerm ||
+        Object.values(row).some((value) =>
+          String(value || '')
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()),
+        )),
+  );
+
+  const stages = cols.map((c) => c.name);
+  const resps = Array.from(
+    new Set(
+      filtered
+        .map((row) => String(row['Verantwortlich'] || '').trim() || '—')
+        .sort(),
+    ),
+  );
+
+  const handleDragEnd = allowDrag ? onDragEnd : () => {};
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `var(--rowheadw) ${stages.map(() => 'var(--colw)').join(' ')}`,
+          gap: '8px',
+          p: 2,
+          alignItems: 'start',
+          overflow: 'auto',
+          minHeight: '100%',
+          width: 'fit-content',
+          minWidth: '100%',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
+            backgroundColor: 'var(--panel)',
+            border: '1px solid var(--line)',
+            borderRadius: '12px',
+            padding: '10px 12px',
+            minHeight: '48px',
+          }}
+        />
+
+        {stages.map((stage) => (
+          <Box
+            key={stage}
+            sx={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 2,
+              backgroundColor: 'var(--panel)',
+              border: '1px solid var(--line)',
+              borderRadius: '12px',
+              padding: '10px 12px',
+              textTransform: 'uppercase',
+              color: 'var(--muted)',
+              letterSpacing: '0.06em',
+              fontSize: '14px',
+              fontWeight: 600,
+            }}
+          >
+            {stage}
+          </Box>
+        ))}
+
+        {resps.map((resp) => (
+          <>
+            <Box
+              key={`header-${resp}`}
+              sx={{
+                position: 'sticky',
+                left: 0,
+                zIndex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 12px',
+                backgroundColor: 'var(--panel)',
+                border: '1px solid var(--line)',
+                borderRadius: '12px',
+                minHeight: '48px',
+              }}
+            >
+              <Typography sx={{ fontWeight: 700 }}>{resp}</Typography>
+              <Typography variant="caption" sx={{ color: 'var(--muted)' }}>
+                {
+                  filtered.filter(
+                    (row) => (String(row['Verantwortlich'] || '').trim() || '—') === resp,
+                  ).length
+                }{' '}
+                Karten
+              </Typography>
+            </Box>
+
+            {stages.map((stage) => {
+              const cellCards = filtered.filter(
+                (row) => inferStage(row) === stage && (String(row['Verantwortlich'] || '').trim() || '—') === resp,
+              );
+
+              return (
+                <Droppable key={`${stage}-${resp}`} droppableId={`${stage}||${resp}`} isDropDisabled={!allowDrag}>
+                  {(provided, snapshot) => (
+                    <Box
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      sx={{
+                        backgroundColor: snapshot.isDraggingOver ? 'rgba(255,255,255,0.06)' : 'var(--panel)',
+                        border: '1px solid var(--line)',
+                        borderRadius: '12px',
+                        minHeight: '140px',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        padding: '8px',
+                        gap: 1,
+                      }}
+                    >
+                      {cellCards.map((card, cardIndex) => renderCard(card, cardIndex))}
+                      {provided.placeholder}
+                    </Box>
+                  )}
+                </Droppable>
+              );
+            })}
+          </>
+        ))}
+      </Box>
+    </DragDropContext>
+  );
+}
+
+export interface KanbanLaneViewProps {
+  rows: any[];
+  cols: { name: string }[];
+  lanes: string[];
+  searchTerm: string;
+  onDragEnd: (result: DropResult) => void;
+  inferStage: (card: any) => string;
+  renderCard: (card: any, index: number) => ReactNode;
+  allowDrag: boolean;
+}
+
+export function KanbanLaneView({ rows, cols, lanes, searchTerm, onDragEnd, inferStage, renderCard, allowDrag }: KanbanLaneViewProps) {
+  const filtered = rows.filter(
+    (row) =>
+      !row['Archived'] &&
+      (!searchTerm ||
+        Object.values(row).some((value) =>
+          String(value || '')
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase()),
+        )),
+  );
+
+  const stages = cols.map((c) => c.name);
+  const laneNames = lanes.length ? lanes : ['Allgemein'];
+
+  const handleDragEnd = allowDrag ? onDragEnd : () => {};
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: `var(--rowheadw) ${stages.map(() => 'var(--colw)').join(' ')}`,
+          gap: '8px',
+          p: 2,
+          alignItems: 'start',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
+            backgroundColor: 'var(--panel)',
+            border: '1px solid var(--line)',
+            borderRadius: '12px',
+            padding: '10px 12px',
+            minHeight: '48px',
+          }}
+        />
+
+        {stages.map((stage) => (
+          <Box
+            key={stage}
+            sx={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 2,
+              backgroundColor: 'var(--panel)',
+              border: '1px solid var(--line)',
+              borderRadius: '12px',
+              padding: '10px 12px',
+              textTransform: 'uppercase',
+              color: 'var(--muted)',
+              letterSpacing: '0.06em',
+              fontSize: '14px',
+              fontWeight: 600,
+            }}
+          >
+            {stage}
+          </Box>
+        ))}
+
+        {laneNames.map((laneName) => (
+          <>
+            <Box
+              key={`header-${laneName}`}
+              sx={{
+                position: 'sticky',
+                left: 0,
+                zIndex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 12px',
+                backgroundColor: 'var(--panel)',
+                border: '1px solid var(--line)',
+                borderRadius: '12px',
+                minHeight: '48px',
+              }}
+            >
+              <Typography sx={{ fontWeight: 700 }}>{laneName}</Typography>
+              <Typography variant="caption" sx={{ color: 'var(--muted)' }}>
+                {
+                  filtered.filter((row) => (row['Swimlane'] || laneNames[0]) === laneName).length
+                }{' '}
+                Karten
+              </Typography>
+            </Box>
+
+            {stages.map((stage) => {
+              const cellCards = filtered.filter(
+                (row) => inferStage(row) === stage && (row['Swimlane'] || laneNames[0]) === laneName,
+              );
+
+              return (
+                <Droppable key={`${stage}-${laneName}`} droppableId={`${stage}||${laneName}`} isDropDisabled={!allowDrag}>
+                  {(provided, snapshot) => (
+                    <Box
+                      ref={provided.innerRef}
+                      {...provided.droppableProps}
+                      sx={{
+                        backgroundColor: snapshot.isDraggingOver ? 'rgba(255,255,255,0.06)' : 'var(--panel)',
+                        border: '1px solid var(--line)',
+                        borderRadius: '12px',
+                        minHeight: '140px',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        padding: '8px',
+                        gap: 1,
+                      }}
+                    >
+                      {cellCards.map((card, cardIndex) => renderCard(card, cardIndex))}
+                      {provided.placeholder}
+                    </Box>
+                  )}
+                </Droppable>
+              );
+            })}
+          </>
+        ))}
+      </Box>
+    </DragDropContext>
+  );
+}

--- a/src/components/team/TeamBoardManagementPanel.tsx
+++ b/src/components/team/TeamBoardManagementPanel.tsx
@@ -1,0 +1,750 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import AddIcon from '@mui/icons-material/Add';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+import { fetchClientProfiles, ClientProfile } from '@/lib/clientProfiles';
+import { isSuperuserEmail } from '@/constants/superuser';
+import SupabaseConfigNotice from '@/components/SupabaseConfigNotice';
+
+interface BoardMemberRow {
+  id: string;
+  profile_id: string;
+}
+
+interface AttendanceRecord {
+  id: string;
+  board_id: string;
+  profile_id: string;
+  week_start: string;
+  status: 'present' | 'absent' | string;
+}
+
+interface TopicRow {
+  id: string;
+  board_id: string;
+  title: string;
+  position: number;
+}
+
+interface MemberWithProfile extends BoardMemberRow {
+  profile: ClientProfile | null;
+}
+
+interface WeekHistoryItem {
+  week: string;
+  date: Date;
+}
+
+interface TeamBoardManagementPanelProps {
+  boardId: string;
+  canEdit: boolean;
+  memberCanSee: boolean;
+}
+
+const formatWeekKey = (date: Date): string => {
+  const temp = new Date(date);
+  const target = startOfWeek(temp);
+  const year = target.getFullYear();
+  const week = isoWeekNumber(target);
+  return `${year}-${String(week).padStart(2, '0')}`;
+};
+
+const parseWeekKey = (value: string): Date => {
+  const [yearPart, weekPart] = value.split('-');
+  const year = Number(yearPart);
+  const week = Number(weekPart);
+  if (!Number.isFinite(year) || !Number.isFinite(week)) {
+    return startOfWeek(new Date());
+  }
+  const simple = new Date(Date.UTC(year, 0, 1));
+  const day = simple.getUTCDay();
+  const diff = (day <= 4 ? day - 1 : day - 8);
+  simple.setUTCDate(simple.getUTCDate() - diff + (week - 1) * 7);
+  return startOfWeek(simple);
+};
+
+function startOfWeek(date: Date): Date {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = (day === 0 ? -6 : 1) - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function isoWeekNumber(date: Date): number {
+  const target = new Date(date.valueOf());
+  const dayNr = (date.getDay() + 6) % 7;
+  target.setDate(target.getDate() - dayNr + 3);
+  const firstThursday = new Date(target.getFullYear(), 0, 4);
+  const diff = target.valueOf() - firstThursday.valueOf();
+  return 1 + Math.round(diff / (7 * 24 * 3600 * 1000));
+}
+
+const weekRangeLabel = (date: Date): string => {
+  const start = startOfWeek(date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 4);
+  const formatter = new Intl.DateTimeFormat('de-DE');
+  return `${formatter.format(start)} – ${formatter.format(end)}`;
+};
+
+const shiftWeek = (weekKey: string, delta: number): string => {
+  const base = parseWeekKey(weekKey);
+  base.setDate(base.getDate() + delta * 7);
+  return formatWeekKey(base);
+};
+
+export default function TeamBoardManagementPanel({ boardId, canEdit, memberCanSee }: TeamBoardManagementPanelProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState<string | null>(null);
+  const [profiles, setProfiles] = useState<ClientProfile[]>([]);
+  const [members, setMembers] = useState<MemberWithProfile[]>([]);
+  const [memberSelect, setMemberSelect] = useState('');
+  const [topics, setTopics] = useState<TopicRow[]>([]);
+  const [attendanceByWeek, setAttendanceByWeek] = useState<
+    Record<string, Record<string, AttendanceRecord | undefined>>
+  >({});
+  const [selectedWeek, setSelectedWeek] = useState<string>(formatWeekKey(new Date()));
+  const [historyWeeks, setHistoryWeeks] = useState<WeekHistoryItem[]>([]);
+  const [attendanceDraft, setAttendanceDraft] = useState<Record<string, boolean>>({});
+  const [attendanceSaving, setAttendanceSaving] = useState(false);
+  const [topicDrafts, setTopicDrafts] = useState<Record<string, string>>({});
+  const [deleteDialog, setDeleteDialog] = useState<{ open: boolean; memberId: string | null }>({ open: false, memberId: null });
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let active = true;
+
+    const run = async () => {
+      setLoading(true);
+      setMessage(null);
+      try {
+        const profileList = await fetchClientProfiles();
+        if (!active) return;
+        setProfiles(profileList);
+
+        const [memberResult, attendanceResult, topicsResult] = await Promise.all([
+          supabase
+            .from('board_members')
+            .select('id, profile_id')
+            .eq('board_id', boardId)
+            .order('created_at', { ascending: true }),
+          supabase
+            .from('board_attendance')
+            .select('id, board_id, profile_id, week_start, status')
+            .eq('board_id', boardId)
+            .order('week_start', { ascending: true }),
+          supabase
+            .from('board_top_topics')
+            .select('id, board_id, title, position')
+            .eq('board_id', boardId)
+            .order('position', { ascending: true }),
+        ]);
+
+        if (memberResult.error) throw memberResult.error;
+        if (attendanceResult.error) throw attendanceResult.error;
+        if (topicsResult.error) throw topicsResult.error;
+
+        const memberRows = (memberResult.data as BoardMemberRow[] | null) ?? [];
+        const mappedMembers: MemberWithProfile[] = memberRows
+          .map((row) => {
+            const profile = profileList.find((entry) => entry.id === row.profile_id) ?? null;
+            if (profile && !isSuperuserEmail(profile.email) && (profile.is_active ?? true)) {
+              return { ...row, profile };
+            }
+            if (!profile) {
+              return { ...row, profile: null };
+            }
+            return null;
+          })
+          .filter((entry): entry is MemberWithProfile => Boolean(entry));
+
+        setMembers(mappedMembers);
+
+        const attendanceRows = (attendanceResult.data as AttendanceRecord[] | null) ?? [];
+        const attendanceMap: Record<string, Record<string, AttendanceRecord>> = {};
+        attendanceRows.forEach((row) => {
+          const weekKey = formatWeekKey(new Date(row.week_start));
+          if (!attendanceMap[weekKey]) {
+            attendanceMap[weekKey] = {};
+          }
+          attendanceMap[weekKey][row.profile_id] = row;
+        });
+        setAttendanceByWeek(attendanceMap);
+
+        const allWeeks = Object.keys(attendanceMap)
+          .map((week) => ({ week, date: parseWeekKey(week) }))
+          .sort((a, b) => b.date.getTime() - a.date.getTime());
+
+        const nextSelected = allWeeks.length ? allWeeks[0].week : formatWeekKey(new Date());
+        setSelectedWeek(nextSelected);
+        setHistoryWeeks(allWeeks.filter((item) => item.week !== nextSelected).slice(0, 10));
+
+        const draft: Record<string, boolean> = {};
+        mappedMembers.forEach((member) => {
+          const existing = attendanceMap[nextSelected]?.[member.profile_id];
+          draft[member.profile_id] = existing ? existing.status !== 'absent' : true;
+        });
+        setAttendanceDraft(draft);
+
+        const topicRows = (topicsResult.data as TopicRow[] | null) ?? [];
+        setTopics(topicRows);
+        const topicDraftValues: Record<string, string> = {};
+        topicRows.forEach((row) => {
+          topicDraftValues[row.id] = row.title;
+        });
+        setTopicDrafts(topicDraftValues);
+      } catch (cause) {
+        if (!active) return;
+        console.error('❌ Fehler beim Laden des Team-Managements', cause);
+        setMessage('Fehler beim Laden der Management-Daten.');
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    run();
+
+    return () => {
+      active = false;
+    };
+  }, [boardId, supabase]);
+
+  const availableProfiles = useMemo(() => {
+    const selected = new Set(members.map((entry) => entry.profile_id));
+    return profiles.filter((profile) => {
+      if (selected.has(profile.id)) {
+        return false;
+      }
+      if (!profile.is_active && profile.is_active !== undefined) {
+        return false;
+      }
+      if (isSuperuserEmail(profile.email)) {
+        return false;
+      }
+      return true;
+    });
+  }, [members, profiles]);
+
+  const selectWeek = (weekKey: string) => {
+    setSelectedWeek(weekKey);
+    const nextDraft: Record<string, boolean> = {};
+    members.forEach((member) => {
+      const existing = attendanceByWeek[weekKey]?.[member.profile_id];
+      nextDraft[member.profile_id] = existing ? existing.status !== 'absent' : true;
+    });
+    setAttendanceDraft(nextDraft);
+    setHistoryWeeks((prev) => {
+      const weekSet = new Map<string, WeekHistoryItem>();
+      prev.forEach((item) => weekSet.set(item.week, item));
+      Object.keys(attendanceByWeek).forEach((week) => {
+        if (week !== weekKey) {
+          weekSet.set(week, { week, date: parseWeekKey(week) });
+        }
+      });
+      weekSet.delete(weekKey);
+      const sorted = Array.from(weekSet.values()).sort((a, b) => b.date.getTime() - a.date.getTime());
+      return sorted.slice(0, 10);
+    });
+  };
+
+  const toggleAttendanceDraft = (profileId: string) => {
+    setAttendanceDraft((prev) => ({ ...prev, [profileId]: !(prev[profileId] ?? true) }));
+  };
+
+  const saveAttendance = async () => {
+    if (!supabase) return;
+    setAttendanceSaving(true);
+    setMessage(null);
+    const weekDate = parseWeekKey(selectedWeek);
+    const payload = members.map((member) => ({
+      board_id: boardId,
+      profile_id: member.profile_id,
+      week_start: weekDate.toISOString().slice(0, 10),
+      status: attendanceDraft[member.profile_id] === false ? 'absent' : 'present',
+    }));
+
+    try {
+      const { error } = await supabase
+        .from('board_attendance')
+        .upsert(payload, { onConflict: 'board_id,profile_id,week_start' });
+      if (error) throw error;
+
+      setMessage('✅ Anwesenheit gespeichert');
+      setTimeout(() => setMessage(null), 4000);
+
+      // Refresh attendance map
+      const copy = { ...attendanceByWeek };
+      if (!copy[selectedWeek]) {
+        copy[selectedWeek] = {};
+      }
+      payload.forEach((entry) => {
+        const existing = attendanceByWeek[selectedWeek]?.[entry.profile_id];
+        copy[selectedWeek][entry.profile_id] = {
+          id: existing?.id ?? `${boardId}-${entry.profile_id}-${selectedWeek}`,
+          board_id: boardId,
+          profile_id: entry.profile_id,
+          week_start: entry.week_start,
+          status: entry.status,
+        };
+      });
+      setAttendanceByWeek(copy);
+    } catch (cause) {
+      console.error('❌ Fehler beim Speichern der Anwesenheit', cause);
+      setMessage('❌ Anwesenheit konnte nicht gespeichert werden.');
+    } finally {
+      setAttendanceSaving(false);
+    }
+  };
+
+  const addMember = async () => {
+    if (!supabase || !memberSelect) return;
+    try {
+      const { error, data } = await supabase
+        .from('board_members')
+        .insert({ board_id: boardId, profile_id: memberSelect })
+        .select()
+        .single();
+      if (error) throw error;
+
+      const profile = profiles.find((entry) => entry.id === memberSelect) ?? null;
+      const nextMember: MemberWithProfile = {
+        id: data.id as string,
+        profile_id: memberSelect,
+        profile,
+      };
+      setMembers((prev) => [...prev, nextMember]);
+      setMemberSelect('');
+      setMessage('✅ Mitglied hinzugefügt');
+      setTimeout(() => setMessage(null), 3000);
+    } catch (cause) {
+      console.error('❌ Fehler beim Hinzufügen eines Mitglieds', cause);
+      setMessage('❌ Mitglied konnte nicht hinzugefügt werden.');
+    }
+  };
+
+  const requestRemoveMember = (memberId: string) => {
+    setDeleteDialog({ open: true, memberId });
+  };
+
+  const confirmRemoveMember = async () => {
+    if (!supabase || !deleteDialog.memberId) {
+      setDeleteDialog({ open: false, memberId: null });
+      return;
+    }
+
+    try {
+      const { error } = await supabase
+        .from('board_members')
+        .delete()
+        .eq('id', deleteDialog.memberId);
+      if (error) throw error;
+
+      setMembers((prev) => prev.filter((entry) => entry.id !== deleteDialog.memberId));
+      setAttendanceDraft((prev) => {
+        const copy = { ...prev };
+        const removed = members.find((entry) => entry.id === deleteDialog.memberId);
+        if (removed) {
+          delete copy[removed.profile_id];
+        }
+        return copy;
+      });
+      setMessage('✅ Mitglied entfernt');
+      setTimeout(() => setMessage(null), 3000);
+    } catch (cause) {
+      console.error('❌ Fehler beim Entfernen eines Mitglieds', cause);
+      setMessage('❌ Mitglied konnte nicht entfernt werden.');
+    } finally {
+      setDeleteDialog({ open: false, memberId: null });
+    }
+  };
+
+  const addTopic = async () => {
+    if (!supabase) return;
+    if (topics.length >= 5) {
+      setMessage('❌ Es können maximal 5 Top-Themen angelegt werden.');
+      setTimeout(() => setMessage(null), 4000);
+      return;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('board_top_topics')
+        .insert({ board_id: boardId, title: '', position: topics.length })
+        .select()
+        .single();
+      if (error) throw error;
+
+      const topic = data as TopicRow;
+      setTopics((prev) => [...prev, topic]);
+      setTopicDrafts((prev) => ({ ...prev, [topic.id]: '' }));
+    } catch (cause) {
+      console.error('❌ Fehler beim Hinzufügen eines Top-Themas', cause);
+      setMessage('❌ Top-Thema konnte nicht angelegt werden.');
+    }
+  };
+
+  const updateTopic = async (topicId: string, value: string) => {
+    if (!supabase) return;
+    try {
+      const { error } = await supabase
+        .from('board_top_topics')
+        .update({ title: value })
+        .eq('id', topicId);
+      if (error) throw error;
+      setMessage('✅ Top-Thema aktualisiert');
+      setTimeout(() => setMessage(null), 3000);
+    } catch (cause) {
+      console.error('❌ Fehler beim Aktualisieren eines Top-Themas', cause);
+      setMessage('❌ Top-Thema konnte nicht aktualisiert werden.');
+    }
+  };
+
+  const deleteTopic = async (topicId: string) => {
+    if (!supabase) return;
+    try {
+      const { error } = await supabase
+        .from('board_top_topics')
+        .delete()
+        .eq('id', topicId);
+      if (error) throw error;
+
+      setTopics((prev) => prev.filter((topic) => topic.id !== topicId));
+      setTopicDrafts((prev) => {
+        const copy = { ...prev };
+        delete copy[topicId];
+        return copy;
+      });
+    } catch (cause) {
+      console.error('❌ Fehler beim Löschen eines Top-Themas', cause);
+      setMessage('❌ Top-Thema konnte nicht gelöscht werden.');
+    }
+  };
+
+  if (!supabase) {
+    return (
+      <Card>
+        <CardContent>
+          <SupabaseConfigNotice />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!memberCanSee) {
+    return (
+      <Card>
+        <CardContent>
+          <Typography>Keine Berechtigung zum Anzeigen der Management-Ansicht.</Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 6, textAlign: 'center' }}>
+        <Typography variant="body1">🔄 Management-Daten werden geladen...</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack spacing={3} sx={{ pb: 6 }}>
+      {message && (
+        <Alert severity={message.startsWith('✅') ? 'success' : message.startsWith('❌') ? 'error' : 'info'}>
+          {message}
+        </Alert>
+      )}
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2} alignItems="flex-start">
+            <Box>
+              <Typography variant="h6">👥 Team-Mitglieder</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Verwalte die Mitglieder des Teamboards.
+              </Typography>
+            </Box>
+            {canEdit && (
+              <Stack direction="row" spacing={1} alignItems="center">
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                  <InputLabel>Mitglied hinzufügen</InputLabel>
+                  <Select
+                    label="Mitglied hinzufügen"
+                    value={memberSelect}
+                    onChange={(event) => setMemberSelect(String(event.target.value))}
+                  >
+                    <MenuItem value="">
+                      <em>Auswählen</em>
+                    </MenuItem>
+                    {availableProfiles.map((profile) => (
+                      <MenuItem key={profile.id} value={profile.id}>
+                        {(profile.full_name || profile.email) + (profile.company ? ` • ${profile.company}` : '')}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  disabled={!memberSelect}
+                  onClick={addMember}
+                >
+                  Hinzufügen
+                </Button>
+              </Stack>
+            )}
+          </Stack>
+
+          <Stack direction="row" spacing={1} flexWrap="wrap" sx={{ mt: 3 }}>
+            {members.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                Noch keine Mitglieder hinterlegt.
+              </Typography>
+            )}
+            {members.map((member) => {
+              const label = member.profile?.full_name || member.profile?.email || 'Unbekannt';
+              const detail = member.profile?.company ? ` • ${member.profile.company}` : '';
+              return (
+                <Chip
+                  key={member.id}
+                  label={`${label}${detail}`}
+                  onDelete={canEdit ? () => requestRemoveMember(member.id) : undefined}
+                  deleteIcon={canEdit ? <DeleteIcon fontSize="small" /> : undefined}
+                  sx={{ mr: 1, mb: 1 }}
+                />
+              );
+            })}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} alignItems={{ xs: 'flex-start', md: 'center' }} spacing={2} justifyContent="space-between">
+            <Box>
+              <Typography variant="h6">🗓️ Anwesenheit</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Dokumentiere, wer beim Termin anwesend war.
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <IconButton onClick={() => selectWeek(shiftWeek(selectedWeek, -1))}>
+                <ArrowBackIcon />
+              </IconButton>
+              <Box sx={{ textAlign: 'center' }}>
+                <Typography variant="subtitle1">KW {selectedWeek.split('-')[1]}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {weekRangeLabel(parseWeekKey(selectedWeek))}
+                </Typography>
+              </Box>
+              <IconButton onClick={() => selectWeek(shiftWeek(selectedWeek, 1))}>
+                <ArrowForwardIcon />
+              </IconButton>
+              {canEdit && (
+                <Button
+                  variant="contained"
+                  sx={{ ml: { md: 2 } }}
+                  onClick={saveAttendance}
+                  disabled={attendanceSaving || members.length === 0}
+                >
+                  Diese Woche speichern
+                </Button>
+              )}
+            </Stack>
+          </Stack>
+
+          <Box sx={{ mt: 3, overflowX: 'auto' }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Mitglied</TableCell>
+                  <TableCell align="center">Aktuelle KW</TableCell>
+                  {historyWeeks.map((history) => (
+                    <TableCell key={history.week} align="center">
+                      <Stack spacing={0.5} alignItems="center">
+                        <Button variant="text" size="small" onClick={() => selectWeek(history.week)}>
+                          KW {history.week.split('-')[1]}
+                        </Button>
+                        <Typography variant="caption" color="text.secondary">
+                          {weekRangeLabel(history.date)}
+                        </Typography>
+                      </Stack>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {members.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={historyWeeks.length + 2}>
+                      <Typography variant="body2" color="text.secondary">
+                        Füge Mitglieder hinzu, um Anwesenheiten zu dokumentieren.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  members.map((member) => {
+                    const profile = member.profile;
+                    const label = profile?.full_name || profile?.email || 'Unbekannt';
+                    const present = attendanceDraft[member.profile_id] ?? true;
+                    return (
+                      <TableRow key={member.id} hover>
+                        <TableCell>
+                          <Stack spacing={0.25}>
+                            <Typography variant="subtitle2">{label}</Typography>
+                            {profile?.company && (
+                              <Typography variant="caption" color="text.secondary">
+                                {profile.company}
+                              </Typography>
+                            )}
+                          </Stack>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Tooltip title={present ? 'Anwesend' : 'Abwesend'}>
+                            <span>
+                              <Checkbox
+                                checked={present}
+                                disabled={!canEdit || attendanceSaving}
+                                icon={<CloseIcon color="error" />}
+                                checkedIcon={<CheckIcon color="success" />}
+                                onChange={() => toggleAttendanceDraft(member.profile_id)}
+                              />
+                            </span>
+                          </Tooltip>
+                        </TableCell>
+                        {historyWeeks.map((history) => {
+                          const record = attendanceByWeek[history.week]?.[member.profile_id];
+                          if (!record) {
+                            return (
+                              <TableCell key={history.week} align="center">
+                                <Typography variant="caption" color="text.secondary">
+                                  —
+                                </Typography>
+                              </TableCell>
+                            );
+                          }
+                          const wasPresent = record.status !== 'absent';
+                          return (
+                            <TableCell key={history.week} align="center">
+                              {wasPresent ? (
+                                <CheckIcon color="success" fontSize="small" />
+                              ) : (
+                                <CloseIcon color="error" fontSize="small" />
+                              )}
+                            </TableCell>
+                          );
+                        })}
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </Box>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2} alignItems={{ xs: 'flex-start', md: 'center' }}>
+            <Box>
+              <Typography variant="h6">⭐ Top-Themen</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Halte die wichtigsten Themen fest (maximal fünf Einträge).
+              </Typography>
+            </Box>
+            {canEdit && (
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                onClick={addTopic}
+                disabled={topics.length >= 5}
+              >
+                Neues Thema
+              </Button>
+            )}
+          </Stack>
+
+          <Stack spacing={2} sx={{ mt: 3 }}>
+            {topics.length === 0 && (
+              <Typography variant="body2" color="text.secondary">
+                Noch keine Top-Themen erfasst.
+              </Typography>
+            )}
+            {topics.map((topic) => (
+              <Stack key={topic.id} direction={{ xs: 'column', md: 'row' }} spacing={1} alignItems={{ xs: 'stretch', md: 'center' }}>
+                <TextField
+                  label="Thema"
+                  value={topicDrafts[topic.id] ?? ''}
+                  onChange={(event) => setTopicDrafts((prev) => ({ ...prev, [topic.id]: event.target.value }))}
+                  onBlur={() => updateTopic(topic.id, topicDrafts[topic.id] ?? '')}
+                  fullWidth
+                  disabled={!canEdit}
+                />
+                {canEdit && (
+                  <Button color="error" onClick={() => deleteTopic(topic.id)} startIcon={<DeleteIcon />}>Löschen</Button>
+                )}
+              </Stack>
+            ))}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Dialog open={deleteDialog.open} onClose={() => setDeleteDialog({ open: false, memberId: null })}>
+        <DialogTitle>Mitglied entfernen?</DialogTitle>
+        <DialogContent>
+          <Typography>Dieses Mitglied wird aus dem Teamboard entfernt.</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteDialog({ open: false, memberId: null })}>Abbrechen</Button>
+          <Button color="error" variant="contained" onClick={confirmRemoveMember}>
+            Entfernen
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  );
+}

--- a/src/components/team/TeamKanbanBoard.tsx
+++ b/src/components/team/TeamKanbanBoard.tsx
@@ -1,0 +1,1141 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Checkbox,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  Grid,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { Add as AddIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { alpha } from '@mui/material/styles';
+import { DragDropContext, Draggable, DropResult, Droppable } from '@hello-pangea/dnd';
+
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+import { fetchClientProfiles, ClientProfile } from '@/lib/clientProfiles';
+import { isSuperuserEmail } from '@/constants/superuser';
+import SupabaseConfigNotice from '@/components/SupabaseConfigNotice';
+import { buildSupabaseAuthHeaders } from '@/lib/sessionHeaders';
+
+interface BoardMember {
+  id: string;
+  profile_id: string;
+}
+
+interface MemberWithProfile extends BoardMember {
+  profile: ClientProfile | null;
+}
+
+export type TeamBoardStatus = 'backlog' | 'flow1' | 'flow' | 'done';
+
+interface TeamBoardCard {
+  rowId: string;
+  cardId: string;
+  description: string;
+  dueDate: string | null;
+  important: boolean;
+  assigneeId: string | null;
+  status: TeamBoardStatus;
+  position: number;
+}
+
+interface TeamKanbanBoardProps {
+  boardId: string;
+}
+
+interface TaskDraft {
+  description: string;
+  dueDate: string;
+  important: boolean;
+  assigneeId: string | null;
+  status: TeamBoardStatus;
+}
+
+interface DroppableInfo {
+  assigneeId: string | null;
+  status: TeamBoardStatus;
+}
+
+const statusLabels: Record<TeamBoardStatus, string> = {
+  backlog: 'Aufgabenspeicher',
+  flow1: 'Flow-1',
+  flow: 'Flow',
+  done: 'Fertig',
+};
+
+const CARD_HEIGHT = 92;
+const CARD_WIDTH = 260;
+
+const defaultDraft: TaskDraft = {
+  description: '',
+  dueDate: '',
+  important: false,
+  assigneeId: null,
+  status: 'backlog',
+};
+
+const droppableKey = (assigneeId: string | null, status: TeamBoardStatus) =>
+  `team|${assigneeId ?? 'unassigned'}|${status}`;
+
+const parseDroppableKey = (value: string): DroppableInfo => {
+  if (!value.startsWith('team|')) {
+    return { assigneeId: null, status: 'backlog' };
+  }
+  const [, rawAssignee, rawStatus] = value.split('|');
+  const status = (['backlog', 'flow1', 'flow', 'done'] as TeamBoardStatus[]).includes(rawStatus as TeamBoardStatus)
+    ? (rawStatus as TeamBoardStatus)
+    : 'backlog';
+  const assigneeId = rawAssignee === 'unassigned' ? null : rawAssignee;
+  return { assigneeId, status };
+};
+
+const buildCardData = (card: TeamBoardCard) => ({
+  type: 'teamTask',
+  description: card.description,
+  dueDate: card.dueDate,
+  important: card.important,
+  assigneeId: card.assigneeId,
+  status: card.status,
+});
+
+const createColumnsMapFromCards = (cards: TeamBoardCard[]) => {
+  const map = new Map<string, TeamBoardCard[]>();
+
+  cards.forEach((card) => {
+    const key = droppableKey(card.assigneeId, card.status);
+    const entries = map.get(key) ?? [];
+    entries.push({ ...card });
+    map.set(key, entries);
+  });
+
+  return map;
+};
+
+const flattenColumnsMap = (map: Map<string, TeamBoardCard[]>) => {
+  const flattened: TeamBoardCard[] = [];
+
+  Array.from(map.keys())
+    .sort()
+    .forEach((key) => {
+      const entries = map.get(key) ?? [];
+      entries
+        .map((entry) => ({ ...entry }))
+        .forEach((entry, index) => {
+          flattened.push({ ...entry, position: index });
+        });
+    });
+
+  return flattened;
+};
+
+const buildPersistPayload = (boardId: string, cards: TeamBoardCard[]) =>
+  cards.map((card) => ({
+    board_id: boardId,
+    card_id: card.cardId,
+    card_data: buildCardData(card),
+    stage: droppableKey(card.assigneeId, card.status),
+    position: card.position ?? 0,
+    project_number: null,
+    project_name: null,
+  }));
+
+const normalizeCard = (row: any): TeamBoardCard | null => {
+  const stageInfo = typeof row.stage === 'string' ? parseDroppableKey(row.stage) : { assigneeId: null, status: 'backlog' as TeamBoardStatus };
+  const payload = (row.card_data ?? {}) as Record<string, unknown>;
+  if (payload && payload.type && payload.type !== 'teamTask' && !String(row.stage || '').startsWith('team|')) {
+    return null;
+  }
+
+  const description = typeof payload.description === 'string' ? payload.description : '';
+  const dueDate = typeof payload.dueDate === 'string' && payload.dueDate ? payload.dueDate : null;
+  const important = Boolean(payload.important);
+
+  let status: TeamBoardStatus = stageInfo.status;
+  if (typeof payload.status === 'string' && ['backlog', 'flow1', 'flow', 'done'].includes(payload.status)) {
+    status = payload.status as TeamBoardStatus;
+  }
+
+  let assigneeId: string | null = stageInfo.assigneeId;
+  if (typeof payload.assigneeId === 'string') {
+    assigneeId = payload.assigneeId;
+  } else if (payload.assigneeId === null) {
+    assigneeId = null;
+  }
+
+  return {
+    rowId: String(row.id),
+    cardId: String(row.card_id ?? row.id ?? crypto.randomUUID()),
+    description,
+    dueDate,
+    important,
+    assigneeId,
+    status,
+    position: typeof row.position === 'number' ? row.position : 0,
+  };
+};
+
+export default function TeamKanbanBoard({ boardId }: TeamKanbanBoardProps) {
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const [members, setMembers] = useState<MemberWithProfile[]>([]);
+  const [cards, setCards] = useState<TeamBoardCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [canModify, setCanModify] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [draft, setDraft] = useState<TaskDraft>(defaultDraft);
+  const [editingCard, setEditingCard] = useState<TeamBoardCard | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [flowSaving, setFlowSaving] = useState(false);
+  const [boardSettings, setBoardSettings] = useState<Record<string, any>>({});
+  const [completedCount, setCompletedCount] = useState(0);
+
+  const persistAllCards = useCallback(
+    async (entries: TeamBoardCard[]) => {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...(await buildSupabaseAuthHeaders(supabase)),
+      };
+
+      const response = await fetch(`/api/boards/${boardId}/cards`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ cards: buildPersistPayload(boardId, entries) }),
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(payload?.error ?? `HTTP ${response.status}`);
+      }
+    },
+    [boardId, supabase],
+  );
+
+  const loadBoardSettings = useCallback(async () => {
+    const headers = await buildSupabaseAuthHeaders(supabase);
+    const response = await fetch(`/api/boards/${boardId}/settings`, {
+      method: 'GET',
+      headers,
+      credentials: 'include',
+    });
+
+    if (!response.ok && response.status !== 404) {
+      const payload = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new Error(payload?.error ?? `HTTP ${response.status}`);
+    }
+
+    if (response.status === 404) {
+      setBoardSettings({});
+      setCompletedCount(0);
+      return;
+    }
+
+    const payload = (await response.json().catch(() => ({}))) as {
+      settings?: Record<string, unknown> | null;
+    };
+
+    const settings = (payload.settings as Record<string, any> | null) ?? {};
+    setBoardSettings(settings);
+
+    const rawCount = Number(
+      settings?.teamBoard && typeof settings.teamBoard.completedCount === 'number'
+        ? settings.teamBoard.completedCount
+        : 0,
+    );
+
+    setCompletedCount(Number.isFinite(rawCount) ? rawCount : 0);
+  }, [boardId, supabase]);
+
+  const persistCompletedCount = useCallback(
+    async (nextCount: number) => {
+      const nextSettings = {
+        ...boardSettings,
+        teamBoard: {
+          ...(boardSettings.teamBoard as Record<string, unknown> | undefined),
+          completedCount: nextCount,
+        },
+      };
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...(await buildSupabaseAuthHeaders(supabase)),
+      };
+
+      const response = await fetch(`/api/boards/${boardId}/settings`, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify({ settings: nextSettings }),
+      });
+
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(payload?.error ?? `HTTP ${response.status}`);
+      }
+
+      setBoardSettings(nextSettings);
+      setCompletedCount(nextCount);
+    },
+    [boardId, boardSettings, supabase],
+  );
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let active = true;
+
+    const loadAll = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const loadedProfiles = await fetchClientProfiles();
+        if (!active) return;
+
+        await loadBoardSettings();
+        await loadMembers(loadedProfiles);
+        await loadCards();
+        await evaluatePermissions(loadedProfiles);
+      } catch (cause) {
+        if (!active) return;
+        console.error('❌ Fehler beim Laden des Teamboards', cause);
+        setError('Fehler beim Laden des Teamboards.');
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadAll();
+
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardId, supabase, loadBoardSettings]);
+
+  const loadMembers = useCallback(
+    async (availableProfiles: ClientProfile[]) => {
+      if (!supabase) return;
+      const { data, error: membershipError } = await supabase
+        .from('board_members')
+        .select('id, profile_id')
+        .eq('board_id', boardId)
+        .order('created_at', { ascending: true });
+
+      if (membershipError) {
+        throw membershipError;
+      }
+
+      const rows = (data as BoardMember[] | null) ?? [];
+      const mapped: MemberWithProfile[] = rows
+        .map((entry) => {
+          const profile = availableProfiles.find((candidate) => candidate.id === entry.profile_id) ?? null;
+          if (profile && (profile.is_active ?? true) && !isSuperuserEmail(profile.email)) {
+            return { ...entry, profile };
+          }
+          if (!profile) {
+            return { ...entry, profile: null };
+          }
+          return null;
+        })
+        .filter((entry): entry is MemberWithProfile => Boolean(entry));
+
+      setMembers(mapped);
+    },
+    [boardId, supabase],
+  );
+
+  const loadCards = useCallback(async () => {
+    if (!supabase) return;
+    const { data, error: cardsError } = await supabase
+      .from('kanban_cards')
+      .select('id, card_id, card_data, stage, position')
+      .eq('board_id', boardId)
+      .order('position', { ascending: true });
+
+    if (cardsError) {
+      throw cardsError;
+    }
+
+    const rows = (data as any[] | null) ?? [];
+    const normalized = rows
+      .map((row) => normalizeCard(row))
+      .filter((card): card is TeamBoardCard => Boolean(card))
+      .map((card) => ({
+        ...card,
+        position: card.position ?? 0,
+      }));
+
+    normalized.sort((a, b) => {
+      const aKey = droppableKey(a.assigneeId, a.status);
+      const bKey = droppableKey(b.assigneeId, b.status);
+      if (aKey === bKey) {
+        return a.position - b.position;
+      }
+      return aKey.localeCompare(bKey);
+    });
+
+    setCards(normalized);
+  }, [boardId, supabase]);
+
+  const evaluatePermissions = useCallback(
+    async (availableProfiles: ClientProfile[]) => {
+      if (!supabase) {
+        setCanModify(false);
+        return;
+      }
+
+      try {
+        const { data: authData, error: authError } = await supabase.auth.getUser();
+        if (authError) {
+          console.error('⚠️ Fehler bei auth.getUser', authError);
+          setCanModify(false);
+          return;
+        }
+
+        const authUser = authData.user;
+        if (!authUser) {
+          setCanModify(false);
+          return;
+        }
+
+        const email = authUser.email ?? '';
+        const profile = availableProfiles.find((candidate) => candidate.id === authUser.id);
+        const role = String(profile?.role ?? '').toLowerCase();
+
+        const elevated =
+          role === 'admin' ||
+          role === 'owner' ||
+          role === 'manager' ||
+          role === 'superuser' ||
+          isSuperuserEmail(email);
+
+        const member = members.some((entry) => entry.profile_id === authUser.id);
+        setCanModify(elevated || member);
+      } catch (cause) {
+        console.error('⚠️ Konnte Berechtigungen nicht auswerten', cause);
+        setCanModify(false);
+      }
+    },
+    [members, supabase],
+  );
+
+  const openCreateDialog = () => {
+    if (!canModify) return;
+    setEditingCard(null);
+    setDraft(defaultDraft);
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (card: TeamBoardCard) => {
+    if (!canModify) return;
+    setEditingCard(card);
+    setDraft({
+      description: card.description,
+      dueDate: card.dueDate ?? '',
+      important: card.important,
+      assigneeId: card.assigneeId,
+      status: card.status,
+    });
+    setDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    if (saving) return;
+    setDialogOpen(false);
+    setEditingCard(null);
+    setDraft(defaultDraft);
+  };
+
+  const handleDraftChange = <K extends keyof TaskDraft>(key: K, value: TaskDraft[K]) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const columnsMap = useMemo(() => {
+    const map = new Map<string, TeamBoardCard[]>();
+    cards.forEach((card) => {
+      const key = droppableKey(card.assigneeId, card.status);
+      const entries = map.get(key) ?? [];
+      entries.push(card);
+      map.set(key, entries);
+    });
+    map.forEach((entries) => entries.sort((a, b) => a.position - b.position));
+    return map;
+  }, [cards]);
+
+  const handleDragEnd = async (result: DropResult) => {
+    if (!canModify) return;
+    if (!result.destination) return;
+
+    const sourceId = result.source.droppableId;
+    const destId = result.destination.droppableId;
+
+    if (sourceId === destId && result.source.index === result.destination.index) {
+      return;
+    }
+
+    const working = createColumnsMapFromCards(cards);
+    const sourceEntries = [...(working.get(sourceId) ?? [])];
+
+    if (result.source.index < 0 || result.source.index >= sourceEntries.length) {
+      return;
+    }
+
+    const [removed] = sourceEntries.splice(result.source.index, 1);
+    working.set(sourceId, sourceEntries);
+
+    const destInfo = parseDroppableKey(destId);
+    const updatedCard: TeamBoardCard = {
+      ...removed,
+      assigneeId: destInfo.assigneeId,
+      status: destInfo.status,
+    };
+
+    const destEntries =
+      sourceId === destId ? sourceEntries : [...(working.get(destId) ?? [])];
+
+    destEntries.splice(result.destination.index, 0, updatedCard);
+    working.set(destId, destEntries);
+
+    const flattened = flattenColumnsMap(working);
+    setCards(flattened);
+    try {
+      await persistAllCards(flattened);
+    } catch (cause) {
+      console.error('❌ Fehler beim Aktualisieren nach Drag & Drop', cause);
+      setError('Fehler beim Speichern der Aufgabenpositionen.');
+      await loadCards();
+    }
+  };
+
+  const saveTask = async () => {
+    if (!supabase) return;
+    if (!draft.description.trim()) {
+      setError('Bitte eine Aufgabenbeschreibung eingeben.');
+      return;
+    }
+
+    if (draft.status !== 'backlog' && !draft.assigneeId) {
+      setError('Bitte ein Teammitglied auswählen, um den Status zu setzen.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const working = createColumnsMapFromCards(cards);
+
+      if (editingCard) {
+        const previousKey = droppableKey(editingCard.assigneeId, editingCard.status);
+        const previousEntries = [...(working.get(previousKey) ?? [])];
+        const previousIndex = previousEntries.findIndex((entry) => entry.cardId === editingCard.cardId);
+
+        if (previousIndex !== -1) {
+          previousEntries.splice(previousIndex, 1);
+        }
+
+        const updatedCard: TeamBoardCard = {
+          ...editingCard,
+          description: draft.description.trim(),
+          dueDate: draft.dueDate || null,
+          important: draft.important,
+          assigneeId: draft.assigneeId,
+          status: draft.status,
+        };
+
+        working.set(previousKey, previousEntries);
+
+        const nextKey = droppableKey(updatedCard.assigneeId, updatedCard.status);
+        const targetEntries =
+          nextKey === previousKey ? previousEntries : [...(working.get(nextKey) ?? [])];
+
+        const insertIndex = nextKey === previousKey && previousIndex >= 0 ? previousIndex : targetEntries.length;
+        targetEntries.splice(insertIndex, 0, updatedCard);
+        working.set(nextKey, targetEntries);
+      } else {
+        const cardId = `team-${crypto.randomUUID()}`;
+        const newCard: TeamBoardCard = {
+          rowId: cardId,
+          cardId,
+          description: draft.description.trim(),
+          dueDate: draft.dueDate || null,
+          important: draft.important,
+          assigneeId: draft.assigneeId,
+          status: draft.status,
+          position: 0,
+        };
+
+        const targetKey = droppableKey(newCard.assigneeId, newCard.status);
+        const targetEntries = [...(working.get(targetKey) ?? [])];
+        targetEntries.push(newCard);
+        working.set(targetKey, targetEntries);
+      }
+
+      const nextCards = flattenColumnsMap(working);
+      setCards(nextCards);
+      await persistAllCards(nextCards);
+      closeDialog();
+    } catch (cause) {
+      console.error('❌ Fehler beim Speichern der Aufgabe', cause);
+      setError('Fehler beim Speichern der Aufgabe.');
+      await loadCards();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteTask = async () => {
+    if (!supabase || !editingCard) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const working = createColumnsMapFromCards(cards);
+      const previousKey = droppableKey(editingCard.assigneeId, editingCard.status);
+      const previousEntries = [...(working.get(previousKey) ?? [])];
+      const index = previousEntries.findIndex((entry) => entry.cardId === editingCard.cardId);
+
+      if (index === -1) {
+        throw new Error('Aufgabe konnte nicht gefunden werden.');
+      }
+
+      previousEntries.splice(index, 1);
+      working.set(previousKey, previousEntries);
+
+      const nextCards = flattenColumnsMap(working);
+      setCards(nextCards);
+      await persistAllCards(nextCards);
+      closeDialog();
+    } catch (cause) {
+      console.error('❌ Fehler beim Löschen der Aufgabe', cause);
+      setError('Fehler beim Löschen der Aufgabe.');
+      await loadCards();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const backlogCards = useMemo(
+    () => cards.filter((card) => card.status === 'backlog').sort((a, b) => a.position - b.position),
+    [cards],
+  );
+
+  const memberColumns = useMemo(() => {
+    return members.map((member) => {
+      const rowCards = cards.filter((card) => card.assigneeId === member.profile_id);
+      return {
+        member,
+        flow1: rowCards.filter((card) => card.status === 'flow1').sort((a, b) => a.position - b.position),
+        flow: rowCards.filter((card) => card.status === 'flow').sort((a, b) => a.position - b.position),
+        done: rowCards.filter((card) => card.status === 'done').sort((a, b) => a.position - b.position),
+      };
+    });
+  }, [cards, members]);
+
+  const doneCardsCount = useMemo(
+    () => cards.filter((card) => card.status === 'done').length,
+    [cards],
+  );
+
+  const handleCompleteFlow = useCallback(async () => {
+    if (!canModify || flowSaving) {
+      return;
+    }
+
+    const finishedCards = cards.filter((card) => card.status === 'done');
+
+    if (finishedCards.length === 0) {
+      return;
+    }
+
+    setFlowSaving(true);
+    setError(null);
+
+    try {
+      const remainingCards = cards.filter((card) => card.status !== 'done');
+      await persistAllCards(remainingCards);
+      await persistCompletedCount(completedCount + finishedCards.length);
+      setCards(remainingCards);
+    } catch (cause) {
+      console.error('❌ Fehler beim Abschließen des Flows', cause);
+      setError('Flow konnte nicht abgeschlossen werden.');
+      await loadCards();
+    } finally {
+      setFlowSaving(false);
+    }
+  }, [canModify, cards, completedCount, flowSaving, loadCards, persistAllCards, persistCompletedCount]);
+
+  const renderCard = (card: TeamBoardCard, index: number) => {
+    const dueDateLabel = card.dueDate ? new Date(card.dueDate).toLocaleDateString('de-DE') : null;
+    const overdue = card.dueDate ? new Date(card.dueDate) < new Date(new Date().toDateString()) : false;
+    return (
+      <Draggable key={card.cardId} draggableId={card.cardId} index={index} isDragDisabled={!canModify}>
+        {(provided, snapshot) => (
+          <Card
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            sx={{
+              width: '100%',
+              maxWidth: CARD_WIDTH,
+              minWidth: { xs: '100%', sm: CARD_WIDTH },
+              mb: 1.5,
+              borderRadius: 2.5,
+              boxShadow: snapshot.isDragging
+                ? '0 18px 30px rgba(15, 23, 42, 0.22)'
+                : '0 4px 14px rgba(15, 23, 42, 0.08)',
+              position: 'relative',
+              cursor: canModify ? 'grab' : 'default',
+              transition: 'transform 0.14s ease, box-shadow 0.14s ease',
+              border: '1px solid',
+              borderColor: card.important ? 'error.light' : 'rgba(148, 163, 184, 0.35)',
+              height: CARD_HEIGHT,
+              minHeight: CARD_HEIGHT,
+              maxHeight: CARD_HEIGHT,
+              display: 'flex',
+              flexDirection: 'column',
+              background: (theme) =>
+                snapshot.isDragging
+                  ? theme.palette.background.paper
+                  : 'linear-gradient(165deg, rgba(255,255,255,0.98) 0%, rgba(244,247,255,0.92) 100%)',
+              '&:hover': {
+                transform: snapshot.isDragging ? 'scale(1.02)' : 'translateY(-2px)',
+                boxShadow: '0 10px 22px rgba(15, 23, 42, 0.16)',
+              },
+            }}
+            onClick={() => openEditDialog(card)}
+          >
+            {card.important && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  left: 8,
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  backgroundColor: '#d32f2f',
+                }}
+              />
+            )}
+            <CardContent
+              sx={{
+                pr: 3,
+                py: 1.5,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 0.75,
+                height: '100%',
+              }}
+            >
+              <Tooltip
+                title={card.description}
+                placement="top-start"
+                arrow
+                disableInteractive
+                enterDelay={1000}
+              >
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    fontWeight: 600,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    whiteSpace: 'normal',
+                    textTransform: 'none',
+                  }}
+                >
+                  {card.description || 'Ohne Beschreibung'}
+                </Typography>
+              </Tooltip>
+              <Box sx={{ mt: 'auto' }}>
+                {dueDateLabel && (
+                  <Typography
+                    variant="caption"
+                    color={overdue ? 'error.main' : 'text.secondary'}
+                    sx={{ fontWeight: overdue ? 600 : 500 }}
+                  >
+                    Fällig: {dueDateLabel}
+                  </Typography>
+                )}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+      </Draggable>
+    );
+  };
+
+  if (!supabase) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <SupabaseConfigNotice />
+      </Box>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ p: 4 }}>
+        <Typography variant="body1">🔄 Teamboard wird geladen...</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        p: { xs: 2, md: 3 },
+        background: 'linear-gradient(180deg, rgba(240, 244, 255, 0.8) 0%, rgba(255, 255, 255, 0.95) 45%)',
+        minHeight: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 3,
+        flexGrow: 1,
+        minWidth: 0,
+      }}
+    >
+      {error && (
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Typography color="error">{error}</Typography>
+          </CardContent>
+        </Card>
+      )}
+
+      <Box sx={{ flexGrow: 1, minHeight: 0, overflow: 'auto', pr: { md: 1 } }}>
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Grid container spacing={3} alignItems="flex-start" wrap="nowrap" sx={{ minWidth: 0 }}>
+          <Grid item xs={12} md={3}>
+            <Card
+              sx={{
+                height: '100%',
+                borderRadius: 3,
+                border: '1px solid',
+                borderColor: 'rgba(148, 163, 184, 0.28)',
+                boxShadow: '0 12px 30px rgba(15, 23, 42, 0.08)',
+              }}
+            >
+              <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Stack spacing={2}>
+                  <Stack direction="row" justifyContent="space-between" alignItems="center">
+                    <Typography variant="h6">Aufgabenspeicher</Typography>
+                    {canModify && (
+                      <IconButton color="primary" size="small" onClick={openCreateDialog}>
+                        <AddIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                  </Stack>
+                  <Droppable droppableId={droppableKey(null, 'backlog')}>
+                    {(provided) => (
+                      <Box
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        sx={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          alignItems: 'stretch',
+                          minHeight: 220,
+                          maxHeight: { xs: 320, md: 480 },
+                          overflowY: 'auto',
+                          border: '1px solid',
+                          borderColor: 'rgba(148, 163, 184, 0.22)',
+                          borderRadius: 2,
+                          p: 1.5,
+                          backgroundColor: (theme) => alpha(theme.palette.primary.light, 0.08),
+                          transition: 'background-color 0.12s ease',
+                          '&:hover': {
+                            backgroundColor: (theme) => alpha(theme.palette.primary.light, 0.16),
+                          },
+                        }}
+                      >
+                        {backlogCards.length === 0 && (
+                          <Typography variant="body2" color="text.secondary">
+                            Keine Aufgaben im Speicher.
+                          </Typography>
+                        )}
+                        {backlogCards.map((card, index) => renderCard(card, index))}
+                        {provided.placeholder}
+                      </Box>
+                    )}
+                  </Droppable>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+
+          <Grid item xs={12} md={9}>
+            <Card
+              sx={{
+                borderRadius: 3,
+                border: '1px solid',
+                borderColor: 'rgba(148, 163, 184, 0.28)',
+                boxShadow: '0 12px 30px rgba(15, 23, 42, 0.08)',
+              }}
+            >
+              <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Stack spacing={2}>
+                  <Typography variant="h6">Team-Flow</Typography>
+                  <Box sx={{ overflowX: 'auto' }}>
+                    <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse' }}>
+                      <Box component="thead">
+                        <Box
+                          component="tr"
+                          sx={{
+                            '& th': {
+                              borderBottom: '1px solid',
+                              borderColor: 'rgba(148, 163, 184, 0.3)',
+                              py: 1,
+                              px: 1.5,
+                              textTransform: 'uppercase',
+                              fontSize: '0.75rem',
+                              letterSpacing: '0.06em',
+                              color: 'text.secondary',
+                            },
+                          }}
+                        >
+                          <Box component="th" align="left">Mitglied</Box>
+                          <Box component="th" align="center" width="25%">
+                            {statusLabels.flow1}
+                          </Box>
+                          <Box component="th" align="center" width="25%">
+                            {statusLabels.flow}
+                          </Box>
+                          <Box component="th" align="center" width="25%">
+                            <Stack spacing={1} alignItems="center">
+                              <Box component="span">{statusLabels.done}</Box>
+                              <Stack direction="row" spacing={1} alignItems="center" justifyContent="center">
+                                <Chip
+                                  size="small"
+                                  color="primary"
+                                  variant="outlined"
+                                  label={`${completedCount} gesamt`}
+                                />
+                                {canModify && (
+                                  <Button
+                                    size="small"
+                                    variant="contained"
+                                    onClick={handleCompleteFlow}
+                                    disabled={flowSaving || doneCardsCount === 0}
+                                    sx={{ textTransform: 'none' }}
+                                  >
+                                    Flow abschließen
+                                  </Button>
+                                )}
+                              </Stack>
+                            </Stack>
+                          </Box>
+                        </Box>
+                      </Box>
+                      <Box component="tbody">
+                        {memberColumns.length === 0 && (
+                          <Box component="tr">
+                            <Box component="td" colSpan={4} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+                              Keine Mitglieder hinterlegt. Füge Mitglieder im Management-Bereich hinzu.
+                            </Box>
+                          </Box>
+                        )}
+                        {memberColumns.map(({ member, flow1, flow, done }) => {
+                          const label = member.profile?.full_name || member.profile?.email || 'Unbekannt';
+                          return (
+                            <Box
+                              component="tr"
+                              key={member.id}
+                              sx={{
+                                '& td': {
+                                  borderBottom: '1px solid',
+                                  borderColor: 'rgba(148, 163, 184, 0.2)',
+                                  px: 1.5,
+                                  py: 1.5,
+                                  verticalAlign: 'top',
+                                  backgroundColor: 'rgba(255,255,255,0.9)',
+                                },
+                              }}
+                            >
+                              <Box component="td" width="25%">
+                                <Stack spacing={0.5}>
+                                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                    {label}
+                                  </Typography>
+                                  {member.profile?.company && (
+                                    <Typography variant="caption" color="text.secondary">
+                                      {member.profile.company}
+                                    </Typography>
+                                  )}
+                                </Stack>
+                              </Box>
+                              {(['flow1', 'flow', 'done'] as TeamBoardStatus[]).map((status) => {
+                                const droppableId = droppableKey(member.profile_id, status);
+                                const rows = status === 'flow1' ? flow1 : status === 'flow' ? flow : done;
+                                return (
+                                  <Box component="td" key={droppableId} width="25%">
+                                    <Droppable droppableId={droppableId}>
+                                      {(providedDroppable) => (
+                                        <Box
+                                          ref={providedDroppable.innerRef}
+                                          {...providedDroppable.droppableProps}
+                                          sx={{
+                                            display: 'flex',
+                                            flexDirection: 'column',
+                                            alignItems: 'stretch',
+                                            minHeight: 160,
+                                            maxHeight: { xs: 220, md: 360 },
+                                            overflowY: 'auto',
+                                            border: '1px solid',
+                                            borderColor: 'rgba(148, 163, 184, 0.22)',
+                                            borderRadius: 2,
+                                            p: 1.5,
+                                            backgroundColor: (theme) => alpha(theme.palette.primary.light, 0.06),
+                                            transition: 'background-color 0.12s ease',
+                                            '&:hover': {
+                                              backgroundColor: (theme) => alpha(theme.palette.primary.light, 0.16),
+                                            },
+                                          }}
+                                        >
+                                          {rows.length === 0 && (
+                                            <Typography variant="body2" color="text.secondary" align="center">
+                                              —
+                                            </Typography>
+                                          )}
+                                          {rows.map((card, index) => renderCard(card, index))}
+                                          {providedDroppable.placeholder}
+                                        </Box>
+                                      )}
+                                    </Droppable>
+                                  </Box>
+                                );
+                              })}
+                            </Box>
+                          );
+                        })}
+                      </Box>
+                    </Box>
+                  </Box>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+          </Grid>
+        </DragDropContext>
+      </Box>
+
+      <Dialog open={dialogOpen} onClose={closeDialog} maxWidth="sm" fullWidth>
+        <DialogTitle>{editingCard ? 'Aufgabe bearbeiten' : 'Neue Aufgabe'}</DialogTitle>
+        <DialogContent dividers>
+          <Stack spacing={2}>
+            <TextField
+              label="Aufgabenbeschreibung"
+              value={draft.description}
+              onChange={(event) => handleDraftChange('description', event.target.value)}
+              fullWidth
+              multiline
+              minRows={2}
+            />
+            <TextField
+              label="Fälligkeitsdatum"
+              type="date"
+              InputLabelProps={{ shrink: true }}
+              value={draft.dueDate}
+              onChange={(event) => handleDraftChange('dueDate', event.target.value)}
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={draft.important}
+                  onChange={(event) => handleDraftChange('important', event.target.checked)}
+                />
+              }
+              label="Wichtige Aufgabe markieren"
+            />
+            <FormControl fullWidth>
+              <InputLabel>Verantwortlich</InputLabel>
+              <Select
+                label="Verantwortlich"
+                value={draft.assigneeId ?? ''}
+                onChange={(event) => {
+                  const value = event.target.value ? String(event.target.value) : null;
+                  handleDraftChange('assigneeId', value);
+                  if (!value && draft.status !== 'backlog') {
+                    handleDraftChange('status', 'backlog');
+                  }
+                }}
+              >
+                <MenuItem value="">
+                  <em>Keinem Mitglied zugeordnet</em>
+                </MenuItem>
+                {members.map((member) => {
+                  const profile = member.profile;
+                  if (!profile) {
+                    return null;
+                  }
+                  return (
+                    <MenuItem key={member.profile_id} value={member.profile_id}>
+                      {profile.full_name || profile.email}
+                      {profile.company ? ` • ${profile.company}` : ''}
+                    </MenuItem>
+                  );
+                })}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <InputLabel>Status</InputLabel>
+              <Select
+                label="Status"
+                value={draft.status}
+                onChange={(event) => handleDraftChange('status', event.target.value as TeamBoardStatus)}
+              >
+                <MenuItem value="backlog">Aufgabenspeicher</MenuItem>
+                <MenuItem value="flow1" disabled={!draft.assigneeId}>
+                  Flow-1
+                </MenuItem>
+                <MenuItem value="flow" disabled={!draft.assigneeId}>
+                  Flow
+                </MenuItem>
+                <MenuItem value="done" disabled={!draft.assigneeId}>
+                  Fertig
+                </MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          {editingCard && (
+            <Button color="error" onClick={deleteTask} disabled={saving} startIcon={<DeleteIcon />}>
+              Löschen
+            </Button>
+          )}
+          <Box sx={{ flexGrow: 1 }} />
+          <Button onClick={closeDialog} disabled={saving}>
+            Abbrechen
+          </Button>
+          <Button onClick={saveTask} disabled={saving} variant="contained">
+            Speichern
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/constants/superuser.ts
+++ b/src/constants/superuser.ts
@@ -1,0 +1,5 @@
+export const SUPERUSER_EMAIL = 'michael@mysight.net';
+
+export function isSuperuserEmail(email: string | null | undefined): boolean {
+  return (email ?? '').toLowerCase() === SUPERUSER_EMAIL;
+}

--- a/src/lib/apiTokens.ts
+++ b/src/lib/apiTokens.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+export interface SessionTokenHeaders {
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+export function readSessionTokens(request: NextRequest): SessionTokenHeaders {
+  const accessToken = request.headers.get('x-supabase-access-token') ?? undefined;
+  const refreshToken = request.headers.get('x-supabase-refresh-token') ?? undefined;
+
+  return { accessToken, refreshToken };
+}

--- a/src/lib/clientProfiles.ts
+++ b/src/lib/clientProfiles.ts
@@ -1,0 +1,62 @@
+export interface ClientProfile {
+  id: string;
+  email: string;
+  full_name: string | null;
+  company: string | null;
+  role: string | null;
+  is_active: boolean;
+  created_at?: string | null;
+}
+
+interface RawClientProfile extends Omit<ClientProfile, 'is_active'> {
+  is_active: boolean | null;
+}
+
+import { getSupabaseBrowserClient } from '@/lib/supabaseBrowser';
+
+interface ProfilesResponse {
+  data?: RawClientProfile[];
+  error?: string;
+}
+
+function mapProfiles(rows: RawClientProfile[] | null | undefined): ClientProfile[] {
+  return (rows ?? []).map(profile => ({
+    ...profile,
+    is_active: profile.is_active ?? true,
+  }));
+}
+
+export async function fetchClientProfiles(): Promise<ClientProfile[]> {
+  const supabase = typeof window === 'undefined' ? null : getSupabaseBrowserClient();
+
+  if (supabase) {
+    try {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, email, full_name, company, role, is_active, created_at')
+        .order('full_name', { ascending: true })
+        .order('email', { ascending: true });
+
+      if (error) {
+        console.warn('Konnte Profile nicht direkt aus Supabase laden:', error.message);
+      } else {
+        return mapProfiles(data as RawClientProfile[] | null | undefined);
+      }
+    } catch (error) {
+      console.warn('Fehler beim direkten Laden der Profile aus Supabase:', error);
+    }
+  }
+
+  const response = await fetch('/api/profiles', {
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => ({}))) as ProfilesResponse;
+    throw new Error(payload?.error ?? `Fehler ${response.status}`);
+  }
+
+  const payload = (await response.json()) as ProfilesResponse;
+  return mapProfiles(payload.data);
+}
+

--- a/src/lib/serverBoardAccess.ts
+++ b/src/lib/serverBoardAccess.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import type { User } from '@supabase/supabase-js';
+
+import { isSuperuserEmail } from '@/constants/superuser';
+import { getServerSessionUser, resolveAdminSupabaseClient } from './supabaseServer';
+import type { AnySupabaseClient } from './supabaseServer';
+import type { SessionTokenHeaders } from './apiTokens';
+
+interface BoardRow {
+  id: string;
+  owner_id: string | null;
+}
+
+interface BoardAccessSuccess {
+  client: AnySupabaseClient;
+  user: User;
+  board: BoardRow;
+}
+
+type BoardAccessResult = BoardAccessSuccess | { response: NextResponse };
+
+interface BoardAccessOptions {
+  allowViewer?: boolean;
+}
+
+export async function ensureBoardMemberAccess(
+  boardId: string,
+  tokens: SessionTokenHeaders = {},
+  options: BoardAccessOptions = {},
+): Promise<BoardAccessResult> {
+  const user = await getServerSessionUser(tokens);
+
+  if (!user) {
+    return {
+      response: NextResponse.json({ error: 'Nicht angemeldet.' }, { status: 401 }),
+    } as const;
+  }
+
+  const { client } = await resolveAdminSupabaseClient(tokens);
+
+  if (isSuperuserEmail(user.email ?? '')) {
+    return { client, user, board: { id: boardId, owner_id: null } } as const;
+  }
+
+  const { data: board, error: boardError } = await client
+    .from('kanban_boards')
+    .select('id, owner_id')
+    .eq('id', boardId)
+    .maybeSingle();
+
+  if (boardError) {
+    const message = boardError.message || 'Fehler beim Laden des Boards.';
+    return { response: NextResponse.json({ error: message }, { status: 500 }) } as const;
+  }
+
+  if (!board) {
+    return { response: NextResponse.json({ error: 'Board nicht gefunden.' }, { status: 404 }) } as const;
+  }
+
+  if (board.owner_id === user.id) {
+    return { client, user, board } as const;
+  }
+
+  const { data: membership, error: membershipError } = await client
+    .from('board_members')
+    .select('id')
+    .eq('board_id', boardId)
+    .eq('profile_id', user.id)
+    .maybeSingle();
+
+  if (membershipError) {
+    const message = membershipError.message || 'Fehler beim Prüfen der Mitgliedschaft.';
+    return { response: NextResponse.json({ error: message }, { status: 500 }) } as const;
+  }
+
+  if (!membership && !options.allowViewer) {
+    return {
+      response: NextResponse.json(
+        {
+          error:
+            'Du bist kein Mitglied dieses Boards. Bitte füge dich zuerst als Mitglied hinzu oder wende dich an eine:n Administrator:in.',
+        },
+        { status: 403 },
+      ),
+    } as const;
+  }
+
+  return { client, user, board } as const;
+}

--- a/src/lib/sessionHeaders.ts
+++ b/src/lib/sessionHeaders.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export async function buildSupabaseAuthHeaders(
+  supabase: SupabaseClient<any, any, any> | null | undefined,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {};
+
+  if (!supabase) {
+    return headers;
+  }
+
+  try {
+    const { data } = await supabase.auth.getSession();
+    const accessToken = data.session?.access_token;
+    const refreshToken = data.session?.refresh_token;
+
+    if (accessToken) {
+      headers['x-supabase-access-token'] = accessToken;
+    }
+
+    if (refreshToken) {
+      headers['x-supabase-refresh-token'] = refreshToken;
+    }
+  } catch (error) {
+    console.warn('⚠️ Konnte Supabase-Session nicht abrufen:', error);
+  }
+
+  return headers;
+}

--- a/src/lib/supabaseBrowser.ts
+++ b/src/lib/supabaseBrowser.ts
@@ -1,0 +1,38 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+let browserClient: SupabaseClient | null = null;
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export function getSupabaseBrowserClient(): SupabaseClient | null {
+  const supabaseUrl = SUPABASE_URL?.trim();
+  const anonKey = SUPABASE_ANON_KEY?.trim();
+
+  if (!supabaseUrl || !anonKey) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Supabase Browser Client: Fehlende NEXT_PUBLIC_SUPABASE_* Variablen.');
+    }
+    return null;
+  }
+
+  if (!browserClient) {
+    browserClient = createClient(supabaseUrl, anonKey);
+  }
+
+  return browserClient;
+}
+
+export function requireSupabaseBrowserClient(): SupabaseClient {
+  const client = getSupabaseBrowserClient();
+  if (!client) {
+    throw new Error(
+      'Supabase ist nicht konfiguriert. Bitte setze NEXT_PUBLIC_SUPABASE_URL und NEXT_PUBLIC_SUPABASE_ANON_KEY.',
+    );
+  }
+  return client;
+}
+
+export function resetSupabaseBrowserClient() {
+  browserClient = null;
+}

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,135 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { User } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnySupabaseClient = SupabaseClient<any, any, any>;
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} ist nicht konfiguriert.`);
+  }
+
+  return value;
+}
+
+function getProjectRef(supabaseUrl: string): string | null {
+  try {
+    const { host } = new URL(supabaseUrl);
+    const [ref] = host.split('.');
+    return ref || null;
+  } catch (error) {
+    console.warn('Konnte Supabase-Projekt-Ref aus URL nicht ermitteln:', error);
+    return null;
+  }
+}
+
+export function getServiceSupabaseClient(): AnySupabaseClient {
+  const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!serviceRoleKey) {
+    throw new Error('Supabase service role client is not configured.');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+}
+
+interface SessionTokens {
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+interface SessionClientResult {
+  client: AnySupabaseClient;
+  accessToken?: string;
+  refreshToken?: string;
+}
+
+async function createSessionClientFromCookies(tokens: SessionTokens = {}): Promise<SessionClientResult> {
+  const supabaseUrl = requireEnv('NEXT_PUBLIC_SUPABASE_URL');
+  const anonKey = requireEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+
+  let accessToken = tokens.accessToken;
+  let refreshToken = tokens.refreshToken;
+
+  if (!accessToken || !refreshToken) {
+    try {
+      const projectRef = getProjectRef(supabaseUrl);
+
+      if (projectRef) {
+        const authCookie = cookies().get(`sb-${projectRef}-auth-token`);
+
+        if (authCookie?.value) {
+          const parsed = JSON.parse(authCookie.value) as {
+            access_token?: string;
+            refresh_token?: string;
+          };
+
+          accessToken = accessToken ?? parsed.access_token;
+          refreshToken = refreshToken ?? parsed.refresh_token;
+        }
+      }
+    } catch (error) {
+      console.warn('Fehler beim Anwenden der Supabase-Session aus Cookies:', error);
+    }
+  }
+
+  const globalHeaders = accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined;
+
+  const client = createClient(supabaseUrl, anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: Boolean(refreshToken),
+    },
+    ...(globalHeaders ? { global: { headers: globalHeaders } } : {}),
+  });
+
+  if (accessToken && refreshToken) {
+    const { error } = await client.auth.setSession({
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    });
+
+    if (error) {
+      console.warn('Konnte Supabase-Session aus Header-Tokens nicht übernehmen:', error.message);
+    }
+  }
+
+  return { client, accessToken, refreshToken };
+}
+
+export async function resolveAdminSupabaseClient(tokens: SessionTokens = {}): Promise<{ client: AnySupabaseClient; isService: boolean }> {
+  try {
+    return { client: getServiceSupabaseClient(), isService: true };
+  } catch (error) {
+    console.warn('Falling back to authenticated Supabase client – service role key missing.');
+    const { client } = await createSessionClientFromCookies(tokens);
+    return { client, isService: false };
+  }
+}
+
+export async function getServerSessionUser(tokens: SessionTokens = {}): Promise<User | null> {
+  try {
+    const { client, accessToken } = await createSessionClientFromCookies(tokens);
+    const { data, error } = accessToken
+      ? await client.auth.getUser(accessToken)
+      : await client.auth.getUser();
+
+    if (error) {
+      console.warn('Konnte aktuellen Supabase-User nicht laden:', error.message);
+      return null;
+    }
+
+    return data.user ?? null;
+  } catch (error) {
+    console.warn('Fehler beim Laden des aktuellen Supabase-Users:', error);
+    return null;
+  }
+}

--- a/src/utils/booleans.ts
+++ b/src/utils/booleans.ts
@@ -1,0 +1,38 @@
+export const toBoolean = (value: unknown): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return false;
+    }
+
+    return [
+      'true',
+      '1',
+      'yes',
+      'ja',
+      'y',
+      'x',
+      'checked',
+      'on'
+    ].includes(normalized);
+  }
+
+  return false;
+};
+
+export const nullableDate = (value: unknown): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? null : date;
+};


### PR DESCRIPTION
## Summary
- add reusable API helpers and a board settings route so member permissions are enforced for loading and updating settings metadata
- switch the original Kanban board to the new settings API and shared token helper so member saves succeed without service credentials
- update the team board to persist via the API and polish the layout with scrollable swimlanes and compact two-line cards

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68f232a34538832a93292542103b667e