### PR TITLE
Handle Supabase client availability in board management loaders

### DIFF
--- a/src/components/board/BoardManagementPanel.tsx
+++ b/src/components/board/BoardManagementPanel.tsx
@@ -559,11 +559,17 @@ export default function BoardManagementPanel({ boardId, canEdit, memberCanSee }:
     setTimeout(() => setMessage(''), 4000);
   };
 
-  const loadBaseData = async (options?: { skipLoading?: boolean }): Promise<boolean> => {
+  async function loadBaseData(options?: { skipLoading?: boolean }): Promise<boolean> {
     const skipLoading = options?.skipLoading ?? false;
     try {
       if (!skipLoading) {
         setLoading(true);
+      }
+
+      if (!supabase) {
+        setMessage('❌ Supabase-Client ist nicht konfiguriert.');
+        setTimeout(() => setMessage(''), 4000);
+        return false;
       }
       const profilePromise = fetchClientProfiles();
 
@@ -698,10 +704,15 @@ export default function BoardManagementPanel({ boardId, canEdit, memberCanSee }:
         setLoading(false);
       }
     }
-  };
+  }
 
   const loadAttendanceHistory = async () => {
     try {
+      if (!supabase) {
+        setMessage('❌ Supabase-Client ist nicht konfiguriert.');
+        setTimeout(() => setMessage(''), 4000);
+        return;
+      }
       const { data, error } = await supabase
         .from('board_attendance')
         .select('*')

--- a/srv/mysight/configs/ecosystem.multi.js
+++ b/srv/mysight/configs/ecosystem.multi.js
@@ -1,0 +1,38 @@
+module.exports = {
+  apps: [
+    {
+      name: "mysight-weber",
+      script: "npm",
+      args: "start",
+      cwd: "/srv/mysight/app",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3001,
+        NODE_OPTIONS: "--max-old-space-size=512",
+        NEXTAUTH_URL: "https://weber.mysight.net",
+        // === TODO: Supabase P1 (weber) eintragen ===
+        NEXT_PUBLIC_SUPABASE_URL: "https://<weber>.supabase.co",
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: "<weber_anon>",
+        SUPABASE_SERVICE_ROLE: "<weber_service_role>",
+        TENANT_SLUG: "weber"
+      }
+    },
+    {
+      name: "mysight-test",
+      script: "npm",
+      args: "start",
+      cwd: "/srv/mysight/app",
+      env: {
+        NODE_ENV: "production",
+        PORT: 3002,
+        NODE_OPTIONS: "--max-old-space-size=512",
+        NEXTAUTH_URL: "https://test.mysight.net",
+        // === TODO: Supabase P2 (test) eintragen ===
+        NEXT_PUBLIC_SUPABASE_URL: "https://<test>.supabase.co",
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: "<test_anon>",
+        SUPABASE_SERVICE_ROLE: "<test_service_role>",
+        TENANT_SLUG: "test"
+      }
+    }
+  ]
+}

--- a/srv/mysight/configs/nginx/landing.local.conf
+++ b/srv/mysight/configs/nginx/landing.local.conf
@@ -1,0 +1,12 @@
+# Nur lokal! Cloudflared greift via http://127.0.0.1:8080 zu.
+server {
+  listen 127.0.0.1:8080;
+  server_name mysight.local;
+
+  root /var/www/mysight;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+}

--- a/srv/mysight/scripts/cloudflare-setup.sh
+++ b/srv/mysight/scripts/cloudflare-setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# === Voraussetzung: Cloudflare Account vorhanden; Domain mysight.net liegt dort. ===
+# Dieses Script:
+#  - installiert cloudflared
+#  - loggt dich ein (Browser-Flow)
+#  - erstellt Tunnel "mysight-pi"
+#  - setzt Routes/DNS für mysight.net, weber.mysight.net, test.mysight.net
+#  - schreibt /etc/cloudflared/config.yml (Ingress)
+#  - installiert systemd-Service und startet Tunnel
+
+TUNNEL_NAME="mysight-pi"
+CLOUDFLARE_BIN="/usr/local/bin/cloudflared"
+
+echo "==> Install cloudflared"
+if ! command -v cloudflared >/dev/null 2>&1; then
+  # ARM (Raspberry Pi) Installation
+  ARCH=$(uname -m)
+  if [[ "$ARCH" == "aarch64" ]]; then
+    curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm64.deb -o /tmp/cloudflared.deb
+  else
+    curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-arm.deb -o /tmp/cloudflared.deb
+  fi
+  sudo dpkg -i /tmp/cloudflared.deb || sudo apt-get -f install -y
+fi
+
+echo "==> cloudflared login (öffne den Link im Browser und wähle mysight.net)"
+cloudflared tunnel login
+
+echo "==> Tunnel create"
+cloudflared tunnel list | grep -q "$TUNNEL_NAME" || cloudflared tunnel create "$TUNNEL_NAME"
+
+TUNNEL_ID=$(cloudflared tunnel list | awk -v name="$TUNNEL_NAME" '$0 ~ name {print $1}' | head -n1)
+echo "Tunnel ID: $TUNNEL_ID"
+[ -n "$TUNNEL_ID" ] || (echo "Tunnel ID nicht gefunden" && exit 1)
+
+sudo mkdir -p /etc/cloudflared
+
+echo "==> config.yml schreiben"
+sudo tee /etc/cloudflared/config.yml >/dev/null <<EOF_INNER
+tunnel: $TUNNEL_ID
+credentials-file: /etc/cloudflared/${TUNNEL_ID}.json
+ingress:
+  - hostname: mysight.net
+    service: http://127.0.0.1:8080
+  - hostname: weber.mysight.net
+    service: http://127.0.0.1:3001
+  - hostname: test.mysight.net
+    service: http://127.0.0.1:3002
+  - service: http_status:404
+EOF_INNER
+
+echo "==> DNS Routes anlegen"
+cloudflared tunnel route dns "$TUNNEL_NAME" mysight.net
+cloudflared tunnel route dns "$TUNNEL_NAME" weber.mysight.net
+cloudflared tunnel route dns "$TUNNEL_NAME" test.mysight.net
+
+echo "==> Systemd Service installieren"
+sudo cloudflared service install
+
+echo "==> Tunnel starten"
+sudo systemctl enable cloudflared
+sudo systemctl restart cloudflared
+sleep 2
+sudo systemctl status cloudflared --no-pager
+
+echo "==> Fertig: https://mysight.net | https://weber.mysight.net | https://test.mysight.net sollten über den Tunnel erreichbar sein."

--- a/srv/mysight/scripts/deploy.sh
+++ b/srv/mysight/scripts/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/my-sight/projektboard-platform.git"
+BRANCH="codex/refactor-originalkanbanboard.tsx-for-maintainability"
+
+APP_DIR="/srv/mysight/app"
+ECOSYSTEM="/srv/mysight/configs/ecosystem.multi.js"
+LANDING_CONF="/srv/mysight/configs/nginx/landing.local.conf"
+
+echo "==> Verzeichnisse"
+sudo mkdir -p /srv/mysight/app /srv/mysight/scripts /srv/mysight/configs/nginx /var/www/mysight
+sudo chown -R $USER:$USER /srv/mysight /var/www/mysight
+
+if [ ! -d "$APP_DIR/.git" ]; then
+  echo "==> Clone Repository"
+  git clone "$REPO_URL" "$APP_DIR"
+fi
+
+cd "$APP_DIR"
+echo "==> Checkout Branch: $BRANCH"
+git fetch origin
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+
+echo "==> Build"
+export NODE_OPTIONS="--max-old-space-size=512"
+npm ci
+npm run build
+
+echo "==> PM2 starten/aktualisieren"
+pm2 start "$ECOSYSTEM" || pm2 restart "$ECOSYSTEM"
+pm2 save
+
+echo "==> Nginx Landing (nur lokal auf 127.0.0.1:8080) aktivieren"
+sudo ln -sf "$LANDING_CONF" /etc/nginx/sites-available/mysight-landing.conf
+sudo ln -sf /etc/nginx/sites-available/mysight-landing.conf /etc/nginx/sites-enabled/mysight-landing.conf
+sudo nginx -t
+sudo systemctl reload nginx
+
+echo "==> Fertig (App läuft lokal auf 3001/3002, Landing auf 127.0.0.1:8080). Cloudflare-Tunnel übernimmt die Öffentlichkeit."

--- a/srv/mysight/scripts/update.sh
+++ b/srv/mysight/scripts/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+APP_DIR="/srv/mysight/app"
+
+cd "$APP_DIR"
+echo "==> Pull latest"
+git pull
+
+echo "==> Rebuild"
+export NODE_OPTIONS="--max-old-space-size=512"
+npm ci
+npm run build
+
+echo "==> Zero-downtime Reload"
+pm2 reload mysight-weber
+pm2 reload mysight-test
+pm2 save
+
+echo "==> Done."

--- a/srv/mysight/supabase/tenant_settings.sql
+++ b/srv/mysight/supabase/tenant_settings.sql
@@ -1,0 +1,16 @@
+create table if not exists tenant_settings (
+  id uuid primary key default gen_random_uuid(),
+  tenant_slug text unique not null,
+  display_name text not null,
+  logo_url text,
+  primary_color text default '#0ea5e9',
+  created_at timestamptz default now()
+);
+
+insert into tenant_settings (tenant_slug, display_name, logo_url, primary_color)
+values ('weber', 'Weber GmbH', null, '#2563eb')
+on conflict (tenant_slug) do nothing;
+
+insert into tenant_settings (tenant_slug, display_name, logo_url, primary_color)
+values ('test', 'Testkunde', null, '#0ea5e9')
+on conflict (tenant_slug) do nothing;

--- a/var/www/mysight/index.html
+++ b/var/www/mysight/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>mysight</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin:0; display:grid; place-items:center; height:100vh; }
+    .card { padding:24px 28px; border:1px solid #e5e7eb; border-radius:12px; box-shadow:0 10px 24px rgba(0,0,0,.06); text-align:center; }
+    a { color:#0ea5e9; text-decoration:none; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>mysight</h1>
+    <p>Projektboards – mandantenfähig.</p>
+    <p><a href="https://weber.mysight.net">weber.mysight.net</a> · <a href="https://test.mysight.net">test.mysight.net</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert the board data loader to an async function declaration to avoid the SWC parsing failure on ARM builds
- guard both board data and attendance loaders when the Supabase client is unavailable and surface a clear message to the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69021b2739d0832a8f106155f730d977