### PR TITLE
Add top topic limit notice and enforce team board due dates

### DIFF
--- a/src/components/board/BoardManagementPanel.tsx
+++ b/src/components/board/BoardManagementPanel.tsx
@@ -814,7 +814,11 @@ export default function BoardManagementPanel({ boardId, canEdit, memberCanSee }:
   };
 
   const addTopic = async () => {
-    if (topics.length >= 5) return;
+    if (topics.length >= 5) {
+      setMessage('❌ Es können maximal 5 Top-Themen angelegt werden.');
+      setTimeout(() => setMessage(''), 4000);
+      return;
+    }
     try {
       const { data, error } = await supabase
         .from('board_top_topics')

--- a/src/components/team/TeamKanbanBoard.tsx
+++ b/src/components/team/TeamKanbanBoard.tsx
@@ -60,8 +60,6 @@ interface TaskDraft {
   description: string;
   dueDate: string;
   important: boolean;
-  assigneeId: string | null;
-  status: TeamBoardStatus;
 }
 
 interface DroppableInfo {
@@ -83,8 +81,6 @@ const defaultDraft: TaskDraft = {
   description: '',
   dueDate: '',
   important: false,
-  assigneeId: null,
-  status: 'backlog',
 };
 
 const droppableKey = (assigneeId: string | null, status: TeamBoardStatus) =>
@@ -453,10 +449,8 @@ export default function TeamKanbanBoard({ boardId }: TeamKanbanBoardProps) {
       description: card.description,
       dueDate: card.dueDate ?? '',
       important: card.important,
-      assigneeId: card.assigneeId,
-      status: card.status,
     });
-    setDueDateError(false);
+    setDueDateError(!card.dueDate);
     setError(null);
     setDialogOpen(true);
   };
@@ -550,8 +544,11 @@ export default function TeamKanbanBoard({ boardId }: TeamKanbanBoardProps) {
       return;
     }
 
-    if (draft.status !== 'backlog' && !draft.assigneeId) {
-      setError('Bitte ein Teammitglied auswählen, um den Status zu setzen.');
+    const currentStatus = editingCard ? editingCard.status : 'backlog';
+    const currentAssigneeId = editingCard ? editingCard.assigneeId : null;
+
+    if (currentStatus !== 'backlog' && !currentAssigneeId) {
+      setError('Bitte ordne die Aufgabe einem Teammitglied in der passenden Spalte zu.');
       return;
     }
 
@@ -575,8 +572,8 @@ export default function TeamKanbanBoard({ boardId }: TeamKanbanBoardProps) {
           description: draft.description.trim(),
           dueDate: draft.dueDate,
           important: draft.important,
-          assigneeId: draft.assigneeId,
-          status: draft.status,
+          assigneeId: currentAssigneeId,
+          status: currentStatus,
         };
 
         working.set(previousKey, previousEntries);
@@ -596,8 +593,8 @@ export default function TeamKanbanBoard({ boardId }: TeamKanbanBoardProps) {
           description: draft.description.trim(),
           dueDate: draft.dueDate,
           important: draft.important,
-          assigneeId: draft.assigneeId,
-          status: draft.status,
+          assigneeId: null,
+          status: 'backlog',
           position: 0,
         };
 


### PR DESCRIPTION
## Summary
- show an error when attempting to add more than five top topics on the project board management page
- simplify the team board task dialog and keep the assignee/status tied to the swim lane
- require team board cards to keep a goal date, surfacing validation immediately when it is missing

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_6903e5021508832a855d5539ee5d6611