### PR TITLE
Introduce board admins and calendar week fields

### DIFF
--- a/docs/supabase-reset.sql
+++ b/docs/supabase-reset.sql
@@ -137,6 +137,7 @@ create table public.kanban_boards (
   settings     jsonb not null default '{"boardType":"standard"}'::jsonb,
   visibility   text not null default 'public' check (visibility in ('public', 'private')),
   owner_id     uuid references auth.users(id) on delete set null,
+  board_admin_id uuid references public.profiles(id) on delete set null,
   user_id      uuid references auth.users(id) on delete set null,
   created_at   timestamptz not null default timezone('utc', now()),
   updated_at   timestamptz not null default timezone('utc', now())
@@ -193,6 +194,7 @@ create table public.board_top_topics (
   board_id    uuid not null references public.kanban_boards(id) on delete cascade,
   title       text not null default '',
   position    integer not null default 0,
+  calendar_week text,
   created_at  timestamptz not null default timezone('utc', now()),
   updated_at  timestamptz not null default timezone('utc', now())
 );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,13 @@ interface Board {
   cardCount?: number;
   settings?: Record<string, unknown> | null;
   boardType: 'standard' | 'team';
+  boardAdminId: string | null;
+}
+
+interface BoardAccessState {
+  isMember: boolean;
+  isOwner: boolean;
+  isBoardAdmin: boolean;
 }
 
 export default function HomePage() {
@@ -56,6 +63,11 @@ export default function HomePage() {
 
   // Board Management States
   const [boards, setBoards] = useState<Board[]>([]);
+  const [selectedBoardAccess, setSelectedBoardAccess] = useState<BoardAccessState>({
+    isMember: false,
+    isOwner: false,
+    isBoardAdmin: false,
+  });
   const [isAdmin, setIsAdmin] = useState(false);
   const [isSuperuser, setIsSuperuser] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -116,7 +128,7 @@ export default function HomePage() {
       return;
     }
     try {
-      let boardsData: Board[] | null = null;
+      let boardsData: any[] | null = null;
 
       try {
         const { data: rpcBoards, error: rpcError } = await supabase
@@ -147,7 +159,7 @@ export default function HomePage() {
 
         if (error) throw error;
 
-        boardsData = (data as Board[]) ?? [];
+        boardsData = (data as any[]) ?? [];
       }
 
       const sanitizedBoards = (boardsData ?? []).map((board) => {
@@ -157,16 +169,35 @@ export default function HomePage() {
             : {};
         const typeRaw = (rawSettings as Record<string, unknown>)['boardType'];
         const boardType = typeof typeRaw === 'string' && typeRaw.toLowerCase() === 'team' ? 'team' : 'standard';
+        const boardAdminRaw = (board as Record<string, unknown>)['board_admin_id'];
+        const boardAdminId = typeof boardAdminRaw === 'string' ? boardAdminRaw : null;
 
         return {
-          ...board,
+          id: String((board as Record<string, unknown>).id ?? ''),
+          name: String((board as Record<string, unknown>).name ?? ''),
+          description: ((board as Record<string, unknown>).description as string) ?? '',
+          created_at: String((board as Record<string, unknown>).created_at ?? new Date().toISOString()),
+          visibility: ((board as Record<string, unknown>).visibility as string) ?? 'public',
+          owner_id: ((board as Record<string, unknown>).owner_id as string | null) ?? null,
+          user_id: ((board as Record<string, unknown>).user_id as string | null) ?? null,
+          cardCount:
+            typeof (board as Record<string, unknown>).cardCount === 'number'
+              ? ((board as Record<string, unknown>).cardCount as number)
+              : undefined,
           settings: rawSettings,
-          visibility: board.visibility ?? 'public',
           boardType,
-        } as Board;
+          boardAdminId,
+        } satisfies Board;
       });
 
       setBoards(sanitizedBoards);
+      setSelectedBoard((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        const updated = sanitizedBoards.find((board) => board.id === prev.id);
+        return updated ? { ...prev, ...updated } : prev;
+      });
 
       const boardsWithoutVisibility = sanitizedBoards
         .filter((board) => !board.visibility || board.visibility === '');
@@ -200,12 +231,110 @@ export default function HomePage() {
       setIsSuperuser(false);
       setSelectedBoard(null);
       setViewMode('list');
+      setSelectedBoardAccess({ isMember: false, isOwner: false, isBoardAdmin: false });
       return;
     }
 
     loadProfile();
     loadBoards();
   }, [user, loadProfile, loadBoards]);
+
+  useEffect(() => {
+    if (!selectedBoard) {
+      setSelectedBoardAccess({ isMember: false, isOwner: false, isBoardAdmin: false });
+    }
+  }, [selectedBoard]);
+
+  useEffect(() => {
+    let active = true;
+
+    const evaluateAccess = async () => {
+      if (!selectedBoard || !supabase || !user) {
+        if (active) {
+          setSelectedBoardAccess({ isMember: false, isOwner: false, isBoardAdmin: false });
+        }
+        return;
+      }
+
+      try {
+        const [boardResult, membershipResult] = await Promise.all([
+          supabase
+            .from('kanban_boards')
+            .select('owner_id, board_admin_id')
+            .eq('id', selectedBoard.id)
+            .maybeSingle(),
+          supabase
+            .from('board_members')
+            .select('id')
+            .eq('board_id', selectedBoard.id)
+            .eq('profile_id', user.id)
+            .maybeSingle(),
+        ]);
+
+        if (!active) return;
+
+        if (boardResult.error) {
+          throw boardResult.error;
+        }
+        if (membershipResult.error) {
+          throw membershipResult.error;
+        }
+
+        const boardRow = (boardResult.data ?? null) as { owner_id: string | null; board_admin_id: string | null } | null;
+        const membershipRow = (membershipResult.data ?? null) as { id: string } | null;
+
+        const ownerId = boardRow?.owner_id ?? null;
+        const adminId = boardRow?.board_admin_id ?? null;
+
+        setSelectedBoardAccess({
+          isMember: Boolean(membershipRow),
+          isOwner: ownerId === user.id,
+          isBoardAdmin: adminId === user.id,
+        });
+
+        if (boardRow) {
+          setBoards((prev) => {
+            let changed = false;
+            const next = prev.map((board) => {
+              if (board.id !== selectedBoard.id) {
+                return board;
+              }
+              const nextOwner = ownerId ?? board.owner_id ?? null;
+              const nextAdmin = adminId ?? null;
+              if (board.owner_id === nextOwner && board.boardAdminId === nextAdmin) {
+                return board;
+              }
+              changed = true;
+              return { ...board, owner_id: nextOwner, boardAdminId: nextAdmin };
+            });
+            return changed ? next : prev;
+          });
+
+          setSelectedBoard((prev) => {
+            if (!prev || prev.id !== selectedBoard.id) {
+              return prev;
+            }
+            const nextOwner = ownerId ?? prev.owner_id ?? null;
+            const nextAdmin = adminId ?? null;
+            if (prev.owner_id === nextOwner && prev.boardAdminId === nextAdmin) {
+              return prev;
+            }
+            return { ...prev, owner_id: nextOwner, boardAdminId: nextAdmin };
+          });
+        }
+      } catch (cause) {
+        if (!active) return;
+        console.error('Fehler beim Auswerten der Board-Rechte:', cause);
+        setSelectedBoardAccess({ isMember: false, isOwner: false, isBoardAdmin: false });
+      }
+    };
+
+    evaluateAccess();
+
+    return () => {
+      active = false;
+    };
+  }, [selectedBoard, supabase, user]);
 
   useEffect(() => {
     const handleBoardMetaUpdated = (event: Event) => {
@@ -280,6 +409,7 @@ export default function HomePage() {
             user_id: user?.id,
             visibility: 'public',
             settings: initialSettings,
+            board_admin_id: user?.id ?? null,
           },
         ])
         .select()
@@ -306,6 +436,10 @@ export default function HomePage() {
           cardCount: typeof base['cardCount'] === 'number' ? (base['cardCount'] as number) : undefined,
           settings: rawSettings,
           boardType,
+          boardAdminId:
+            typeof base['board_admin_id'] === 'string'
+              ? (base['board_admin_id'] as string)
+              : user?.id ?? null,
         };
 
         setBoards((prev) => [createdBoard, ...prev]);
@@ -532,8 +666,19 @@ export default function HomePage() {
 
         <BoardManagementPanel
           boardId={selectedBoard.id}
-          canEdit={isAdmin || isSuperuser}
-          memberCanSee={true}
+          canEdit={
+            isAdmin ||
+            isSuperuser ||
+            selectedBoardAccess.isOwner ||
+            selectedBoardAccess.isBoardAdmin
+          }
+          memberCanSee={
+            isAdmin ||
+            isSuperuser ||
+            selectedBoardAccess.isMember ||
+            selectedBoardAccess.isOwner ||
+            selectedBoardAccess.isBoardAdmin
+          }
         />
       </Container>
     );
@@ -647,8 +792,19 @@ export default function HomePage() {
 
         <TeamBoardManagementPanel
           boardId={selectedBoard.id}
-          canEdit={isAdmin || isSuperuser}
-          memberCanSee={true}
+          canEdit={
+            isAdmin ||
+            isSuperuser ||
+            selectedBoardAccess.isOwner ||
+            selectedBoardAccess.isBoardAdmin
+          }
+          memberCanSee={
+            isAdmin ||
+            isSuperuser ||
+            selectedBoardAccess.isMember ||
+            selectedBoardAccess.isOwner ||
+            selectedBoardAccess.isBoardAdmin
+          }
         />
       </Container>
     );

--- a/src/lib/serverBoardAccess.ts
+++ b/src/lib/serverBoardAccess.ts
@@ -9,6 +9,7 @@ import type { SessionTokenHeaders } from './apiTokens';
 interface BoardRow {
   id: string;
   owner_id: string | null;
+  board_admin_id: string | null;
 }
 
 interface BoardAccessSuccess {
@@ -39,12 +40,12 @@ export async function ensureBoardMemberAccess(
   const { client } = await resolveAdminSupabaseClient(tokens);
 
   if (isSuperuserEmail(user.email ?? '')) {
-    return { client, user, board: { id: boardId, owner_id: null } } as const;
+    return { client, user, board: { id: boardId, owner_id: null, board_admin_id: null } } as const;
   }
 
   const { data: board, error: boardError } = await client
     .from('kanban_boards')
-    .select('id, owner_id')
+    .select('id, owner_id, board_admin_id')
     .eq('id', boardId)
     .maybeSingle();
 
@@ -57,7 +58,7 @@ export async function ensureBoardMemberAccess(
     return { response: NextResponse.json({ error: 'Board nicht gefunden.' }, { status: 404 }) } as const;
   }
 
-  if (board.owner_id === user.id) {
+  if (board.owner_id === user.id || board.board_admin_id === user.id) {
     return { client, user, board } as const;
   }
 
@@ -73,7 +74,7 @@ export async function ensureBoardMemberAccess(
     return { response: NextResponse.json({ error: message }, { status: 500 }) } as const;
   }
 
-  if (!membership && !options.allowViewer) {
+  if (!membership && !options.allowViewer && board.board_admin_id !== user.id) {
     return {
       response: NextResponse.json(
         {


### PR DESCRIPTION
## Summary
- store a dedicated board_admin_id on boards and surface board-admin selection in the admin dashboard
- allow board and team management panels to capture a calendar week per top topic and persist it via Supabase
- grant board admins full modify rights, extend member permissions checks, and prevent kanban swimlanes from scrolling cards out of view

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_6903e5021508832a855d5539ee5d6611